### PR TITLE
force default tail flags on commands service and daemon logs to 10,000 lines

### DIFF
--- a/packages/cli/src/commands/daemon/logs.ts
+++ b/packages/cli/src/commands/daemon/logs.ts
@@ -10,7 +10,7 @@ export default class Logs extends Command {
     ...Command.flags,
     tail: flags.integer({
       description:  'Display the last N lines',
-      default: -1
+      default: 10000
     }),
     follow: flags.boolean({
       description: 'Follow logs',

--- a/packages/cli/src/commands/service/logs.ts
+++ b/packages/cli/src/commands/service/logs.ts
@@ -44,7 +44,7 @@ export default class ServiceLogs extends Command {
     }),
     tail: flags.integer({
       description: 'Display the last N lines',
-      default: -1
+      default: 10000
     }),
     follow: flags.boolean({
       description: 'Follow log output',


### PR DESCRIPTION



Related to https://github.com/mesg-foundation/js-sdk/issues/139