### PR TITLE
Update process name/key

### DIFF
--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -3,7 +3,15 @@
 ## [Unreleased](https://github.com/mesg-foundation/js-sdk/releases/tag/vX.X.X)
 
 #### Breaking Changes
+
+- The key in the process's nodes had been moved from the node resource to the root of the node. 
+- `CreateProcessRequest` now accepts a `name` instead of a `key`.
+- `Execution` contains a `nodeKey` instead of `stepID`
+
 #### Added
+
+- Add proto validation information
+
 #### Changed
 #### Fixed
 #### Removed

--- a/packages/api/src/protobuf/api/event.proto
+++ b/packages/api/src/protobuf/api/event.proto
@@ -27,18 +27,22 @@ message StreamEventRequest {
   message Filter {
     // hash to filter events.
     bytes hash = 1 [
+      (gogoproto.moretags) = 'validate:"omitempty,hash"',
       (gogoproto.customtype) = "github.com/mesg-foundation/engine/hash.Hash",
       (gogoproto.nullable) = false
     ];
 
     // instance's hash to filter events.
     bytes instanceHash = 2 [
+      (gogoproto.moretags) = 'validate:"omitempty,hash"',
       (gogoproto.customtype) = "github.com/mesg-foundation/engine/hash.Hash",
       (gogoproto.nullable) = false
     ];
 
     // key is the key of the event.
-    string key = 3;
+    string key = 3 [
+      (gogoproto.moretags) = 'validate:"printascii"'
+    ];
   }
 
   // Filter used to filter a stream of events.
@@ -49,12 +53,15 @@ message StreamEventRequest {
 message CreateEventRequest {
   // instanceHash is hash of instance that can proceed an execution.
   bytes instanceHash = 1 [
+    (gogoproto.moretags) = 'validate:"required,hash"',
     (gogoproto.customtype) = "github.com/mesg-foundation/engine/hash.Hash",
     (gogoproto.nullable) = false
   ];
 
   // key is the key of the event.
-  string key = 2;
+  string key = 2 [
+    (gogoproto.moretags) = 'validate:"required,printascii"'
+  ];
 
   // data is the data for the event.
   mesg.protobuf.Struct data = 3;

--- a/packages/api/src/protobuf/api/execution.proto
+++ b/packages/api/src/protobuf/api/execution.proto
@@ -33,23 +33,40 @@ service Execution {
 
 // CreateExecutionRequest defines request to create a single execution.
 message CreateExecutionRequest {
-  string taskKey = 2;
+  // taskKey to filter executions.
+  string taskKey = 2 [
+    (gogoproto.moretags) = 'validate:"required,printascii"'
+  ];
+
   mesg.protobuf.Struct inputs = 3;
-  repeated string tags = 4;
+
+  // tags the execution.
+  repeated string tags = 4 [
+    (gogoproto.moretags) = 'validate:"dive,printascii"'
+  ];
+
   bytes parentHash = 5 [
+    (gogoproto.moretags) = 'validate:"omitempty,hash"',
     (gogoproto.customtype) = "github.com/mesg-foundation/engine/hash.Hash",
     (gogoproto.nullable) = false
   ];
+
   bytes eventHash = 6 [
+    (gogoproto.moretags) = 'validate:"omitempty,hash"',
     (gogoproto.customtype) = "github.com/mesg-foundation/engine/hash.Hash",
     (gogoproto.nullable) = false
   ];
+
   bytes processHash = 7 [
+    (gogoproto.moretags) = 'validate:"omitempty,hash"',
     (gogoproto.customtype) = "github.com/mesg-foundation/engine/hash.Hash",
     (gogoproto.nullable) = false
   ];
-  string stepID = 8;
+
+  string nodeKey = 8;
+
   bytes executorHash = 9 [
+    (gogoproto.moretags) = 'validate:"omitempty,hash"',
     (gogoproto.customtype) = "github.com/mesg-foundation/engine/hash.Hash",
     (gogoproto.nullable) = false
   ];
@@ -68,6 +85,7 @@ message CreateExecutionResponse {
 message GetExecutionRequest {
   // Execution's hash to fetch.
   bytes hash = 1 [
+    (gogoproto.moretags) = 'validate:"required,hash"',
     (gogoproto.customtype) = "github.com/mesg-foundation/engine/hash.Hash",
     (gogoproto.nullable) = false
   ];
@@ -82,18 +100,24 @@ message StreamExecutionRequest{
 
     // Instance's hash to filter executions.
     bytes instanceHash = 2 [
+      (gogoproto.moretags) = 'validate:"omitempty,hash"',
       (gogoproto.customtype) = "github.com/mesg-foundation/engine/hash.Hash",
       (gogoproto.nullable) = false
     ];
 
     // taskKey to filter executions.
-    string taskKey = 3;
+    string taskKey = 3 [
+      (gogoproto.moretags) = 'validate:"printascii"'
+    ];
 
     // tags to filter executions. All tags needs to be present in the execution.
-    repeated string tags = 4;
+    repeated string tags = 4 [
+      (gogoproto.moretags) = 'validate:"dive,printascii"'
+    ];
     
     // Executor's hash to filter executions.
     bytes executorHash = 5 [
+      (gogoproto.moretags) = 'validate:"omitempty,hash"',
       (gogoproto.customtype) = "github.com/mesg-foundation/engine/hash.Hash",
       (gogoproto.nullable) = false
     ];
@@ -107,6 +131,7 @@ message StreamExecutionRequest{
 message UpdateExecutionRequest {
   // Hash represents execution.
   bytes hash = 1 [
+    (gogoproto.moretags) = 'validate:"required,hash"',
     (gogoproto.customtype) = "github.com/mesg-foundation/engine/hash.Hash",
     (gogoproto.nullable) = false
   ];

--- a/packages/api/src/protobuf/api/instance.proto
+++ b/packages/api/src/protobuf/api/instance.proto
@@ -23,6 +23,7 @@ service Instance {
 // The request's data for the `Get` API.
 message GetInstanceRequest {
   bytes hash = 1 [
+    (gogoproto.moretags) = 'validate:"required,hash"',
     (gogoproto.customtype) = "github.com/mesg-foundation/engine/hash.Hash",
     (gogoproto.nullable) = false
   ];
@@ -34,6 +35,7 @@ message ListInstanceRequest {
   message Filter {
     // Service hash to filter executions.
     bytes serviceHash = 1 [
+      (gogoproto.moretags) = 'validate:"omitempty,hash"',
       (gogoproto.customtype) = "github.com/mesg-foundation/engine/hash.Hash",
       (gogoproto.nullable) = false
     ];

--- a/packages/api/src/protobuf/api/process.proto
+++ b/packages/api/src/protobuf/api/process.proto
@@ -30,9 +30,14 @@ service Process {
 
 // The request's data for the `Create` API.
 message CreateProcessRequest {
-  string key = 2;           // Process's key
-  repeated types.Process.Node nodes = 4;  // List of nodes of the process.
-  repeated types.Process.Edge edges = 5;  // List of edges of the process.
+  // Process's name
+  string name = 2;
+
+  // List of nodes of the process.
+  repeated types.Process.Node nodes = 4;
+
+  // List of edges of the process.
+  repeated types.Process.Edge edges = 5;
 }
 
 // The response's data for the `Create` API.

--- a/packages/api/src/protobuf/api/runner.proto
+++ b/packages/api/src/protobuf/api/runner.proto
@@ -30,6 +30,7 @@ service Runner {
 // The request's data for the `Get` API.
 message GetRunnerRequest {
   bytes hash = 1 [
+    (gogoproto.moretags) = 'validate:"required,hash"',
     (gogoproto.customtype) = "github.com/mesg-foundation/engine/hash.Hash",
     (gogoproto.nullable) = false
   ];
@@ -41,12 +42,15 @@ message ListRunnerRequest {
   message Filter {
     // Filter by instance hash.
     bytes instanceHash = 1 [
+      (gogoproto.moretags) = 'validate:"hash"',
       (gogoproto.customtype) = "github.com/mesg-foundation/engine/hash.Hash",
       (gogoproto.nullable) = false
     ];
 
     // Filter by address
-    string address = 2;
+    string address = 2 [
+      (gogoproto.moretags) = 'validate:"accaddress"'
+    ];
   }
 
   // Filter used to filter runners.
@@ -63,12 +67,15 @@ message ListRunnerResponse {
 message CreateRunnerRequest {
   // Service's hash to start the runner with.
   bytes serviceHash = 1 [
+    (gogoproto.moretags) = 'validate:"hash"',
     (gogoproto.customtype) = "github.com/mesg-foundation/engine/hash.Hash",
     (gogoproto.nullable) = false
   ];
 
   // Environmental variables to start the runner with.
-  repeated string env = 2;
+  repeated string env = 2 [
+    (gogoproto.moretags) = 'validate:"unique,dive,env"'
+  ];
 }
 
 // The response's data for the `Create` API.
@@ -84,6 +91,7 @@ message CreateRunnerResponse {
 message DeleteRunnerRequest {
   // Runner's hash
   bytes hash = 1 [
+    (gogoproto.moretags) = 'validate:"required,hash"',
     (gogoproto.customtype) = "github.com/mesg-foundation/engine/hash.Hash",
     (gogoproto.nullable) = false
   ];
@@ -94,4 +102,3 @@ message DeleteRunnerRequest {
 
 // The response's data for the `Delete` API.
 message DeleteRunnerResponse {}
-

--- a/packages/api/src/protobuf/api/service.proto
+++ b/packages/api/src/protobuf/api/service.proto
@@ -33,33 +33,50 @@ service Service {
 // The request's data for the `Create` API.
 message CreateServiceRequest {
   // Service's sid.
-  string sid = 1;
+  string sid = 1 [
+    (gogoproto.moretags) = 'validate:"printascii,max=63,domain"'
+  ];
 
   // Service's name.
-  string name = 2;
+  string name = 2 [
+    (gogoproto.moretags) = 'validate:"required,printascii"'
+  ];
 
   // Service's description.
-  string description = 3;
+  string description = 3 [
+    (gogoproto.moretags) = 'validate:"printascii"'
+  ];
 
   // Configurations related to the service
   types.Service.Configuration configuration = 4 [
+    (gogoproto.moretags) = 'validate:"required"',
     (gogoproto.nullable) = false
   ];
 
   // The list of tasks this service can execute.
-  repeated types.Service.Task tasks = 5;
+  repeated types.Service.Task tasks = 5 [
+    (gogoproto.moretags) = 'validate:"dive,required"'
+  ];
 
   // The list of events this service can emit.
-  repeated types.Service.Event events = 6;
+  repeated types.Service.Event events = 6 [
+    (gogoproto.moretags) = 'validate:"dive,required"'
+  ];
 
   // The container dependencies this service requires.
-  repeated types.Service.Dependency dependencies = 7;
+  repeated types.Service.Dependency dependencies = 7 [
+    (gogoproto.moretags) = 'validate:"dive,required"'
+  ];
 
   // Service's repository url.
-  string repository = 8;
+  string repository = 8 [
+    (gogoproto.moretags) = 'validate:"omitempty,uri"'
+  ];
 
   // The hash id of service's source code on IPFS.
-  string source = 9;
+  string source = 9 [
+    (gogoproto.moretags) = 'validate:"required,printascii"'
+  ];
 }
 
 // The response's data for the `Create` API.
@@ -75,6 +92,7 @@ message CreateServiceResponse {
 message GetServiceRequest {
   // The service's hash to fetch.
   bytes hash = 1 [
+    (gogoproto.moretags) = 'validate:"required,hash"',
     (gogoproto.customtype) = "github.com/mesg-foundation/engine/hash.Hash",
     (gogoproto.nullable) = false
   ];
@@ -93,6 +111,7 @@ message ListServiceResponse {
 message ExistsServiceRequest {
   // The service's hash of the existing service. This hash is nil if exists is fals.
   bytes hash = 1 [
+    (gogoproto.moretags) = 'validate:"required,hash"',
     (gogoproto.customtype) = "github.com/mesg-foundation/engine/hash.Hash",
     (gogoproto.nullable) = false
   ];

--- a/packages/api/src/protobuf/types/account.proto
+++ b/packages/api/src/protobuf/types/account.proto
@@ -10,5 +10,7 @@ option (gogoproto.goproto_getters_all) = false;
 // Account represents service's account.
 message Account {
   string name = 1;
-  string address = 2;
+  string address = 2 [
+    (gogoproto.moretags) = 'validate:"accaddress"'
+  ];
 }

--- a/packages/api/src/protobuf/types/event.proto
+++ b/packages/api/src/protobuf/types/event.proto
@@ -19,14 +19,14 @@ message Event {
 
   // instanceHash is hash of instance that can proceed an execution.
   bytes instanceHash = 2 [
-    (gogoproto.moretags) = 'hash:"name:2"',
+    (gogoproto.moretags) = 'hash:"name:2" validate:"required,hash"',
     (gogoproto.customtype) = "github.com/mesg-foundation/engine/hash.Hash",
     (gogoproto.nullable) = false
   ];
 
   // key is the key of the event.
   string key = 3 [
-    (gogoproto.moretags) = 'hash:"name:3"'
+    (gogoproto.moretags) = 'hash:"name:3" validate:"required,printascii"'
   ];
 
   // data is the data for the event.

--- a/packages/api/src/protobuf/types/execution.proto
+++ b/packages/api/src/protobuf/types/execution.proto
@@ -88,7 +88,7 @@ message Execution {
 
   // tags are optionally associated with execution by the user.
   repeated string tags = 10 [
-    (gogoproto.moretags) = 'hash:"name:10"'
+    (gogoproto.moretags) = 'hash:"name:10" validate:"dive,printascii"'
   ];
 
   // processHash is the unique hash of the process associated to this execution.
@@ -98,8 +98,8 @@ message Execution {
     (gogoproto.nullable) = false
   ];
 
-  // step of the process.
-  string stepID = 12 [
+  // node key of the process.
+  string nodeKey = 12 [
     (gogoproto.moretags) = 'hash:"name:12"'
   ];
 

--- a/packages/api/src/protobuf/types/process.proto
+++ b/packages/api/src/protobuf/types/process.proto
@@ -14,11 +14,6 @@ message Process {
   // Node of the process
   message Node {
     message Result {
-      // Key that identifies the node.
-      string key = 1 [
-        (gogoproto.moretags) = 'hash:"name:1" validate:"required"'
-      ];
-
       // Hash of the instance that triggers the process.
       bytes instanceHash = 2 [
         (gogoproto.moretags) = 'hash:"name:2" validate:"required"',
@@ -33,11 +28,6 @@ message Process {
     }
 
     message Event {
-      // Key that identifies the node.
-      string key = 1 [
-        (gogoproto.moretags) = 'hash:"name:1" validate:"required"'
-      ];
-
       // Hash of the instance that triggers the process.
       bytes instanceHash = 2 [
         (gogoproto.moretags) = 'hash:"name:2" validate:"required"',
@@ -52,11 +42,6 @@ message Process {
     }
 
     message Task {
-      // Key that identifies the node.
-      string key = 1 [
-        (gogoproto.moretags) = 'hash:"name:1" validate:"required"'
-      ];
-
       // Hash of the instance to execute.
       bytes instanceHash = 2 [
         (gogoproto.moretags) = 'hash:"name:2" validate:"required"',
@@ -100,11 +85,6 @@ message Process {
         }
       }
 
-      // Key of the mapping.
-      string key = 1 [
-        (gogoproto.moretags) = 'hash:"name:1" validate:"required"'
-      ];
-
       // Outputs of the mapping.
       repeated Output outputs = 2 [
         (gogoproto.moretags) = 'hash:"name:2" validate:"dive,required"'
@@ -138,11 +118,6 @@ message Process {
         ];
       }
 
-      // Key for the filter
-      string key = 1 [
-        (gogoproto.moretags) = 'hash:"name:1" validate:"required"'
-      ];
-
       // List of condition to apply for this filter
       repeated Condition conditions = 2 [
         (gogoproto.moretags) = 'hash:"name:2"',
@@ -150,25 +125,30 @@ message Process {
       ];
     }
 
+    // Key that identifies the node.
+    string key = 1 [
+      (gogoproto.moretags) = 'hash:"name:1" validate:"required"'
+    ];
+
     oneof type {
       // Result is a trigger that listens for a specific result.
-      Result result = 1 [
+      Result result = 2 [
         (gogoproto.moretags) = 'hash:"name:1"'
       ];
       // Event is a trigger that listens for a specific event.
-      Event event = 2 [
+      Event event = 3 [
         (gogoproto.moretags) = 'hash:"name:2"'
       ];
       // Task is a command to execute a specific task.
-      Task task = 3 [
+      Task task = 4 [
         (gogoproto.moretags) = 'hash:"name:3"'
       ];
       // Map is a set of instructions to convert data.
-      Map map = 4 [
+      Map map = 5 [
         (gogoproto.moretags) = 'hash:"name:4"'
       ];
       // Filter is a list of condition to apply on data.
-      Filter filter = 5 [
+      Filter filter = 6 [
         (gogoproto.moretags) = 'hash:"name:5"'
       ];
     }
@@ -193,8 +173,8 @@ message Process {
     (gogoproto.nullable) = false
   ];
 
-  // Process's key
-  string key = 2 [
+  // Process's name
+  string name = 2 [
     (gogoproto.moretags) = 'hash:"name:2" validate:"required"'
   ];
 

--- a/packages/api/src/protobuf/types/service.proto
+++ b/packages/api/src/protobuf/types/service.proto
@@ -6,6 +6,7 @@ package mesg.types;
 option go_package = "github.com/mesg-foundation/engine/service";
 
 option (gogoproto.goproto_getters_all) = false;
+option (gogoproto.equal_all) = true;
 
 // Service represents the service's type.
 message Service {

--- a/packages/api/src/typedef/execution.d.ts
+++ b/packages/api/src/typedef/execution.d.ts
@@ -55,8 +55,8 @@ declare namespace mesg {
                 /** Execution processHash */
                 processHash?: (Uint8Array|null);
 
-                /** Execution stepID */
-                stepID?: (string|null);
+                /** Execution nodeKey */
+                nodeKey?: (string|null);
 
                 /** Execution executorHash */
                 executorHash?: (Uint8Array|null);
@@ -104,8 +104,8 @@ declare namespace mesg {
                 /** Execution processHash. */
                 public processHash: Uint8Array;
 
-                /** Execution stepID. */
-                public stepID: string;
+                /** Execution nodeKey. */
+                public nodeKey: string;
 
                 /** Execution executorHash. */
                 public executorHash: Uint8Array;
@@ -358,8 +358,8 @@ declare namespace mesg {
                 /** CreateExecutionRequest processHash */
                 processHash?: (Uint8Array|null);
 
-                /** CreateExecutionRequest stepID */
-                stepID?: (string|null);
+                /** CreateExecutionRequest nodeKey */
+                nodeKey?: (string|null);
 
                 /** CreateExecutionRequest executorHash */
                 executorHash?: (Uint8Array|null);
@@ -392,8 +392,8 @@ declare namespace mesg {
                 /** CreateExecutionRequest processHash. */
                 public processHash: Uint8Array;
 
-                /** CreateExecutionRequest stepID. */
-                public stepID: string;
+                /** CreateExecutionRequest nodeKey. */
+                public nodeKey: string;
 
                 /** CreateExecutionRequest executorHash. */
                 public executorHash: Uint8Array;

--- a/packages/api/src/typedef/process.d.ts
+++ b/packages/api/src/typedef/process.d.ts
@@ -16,8 +16,8 @@ declare namespace mesg {
                 /** Process hash */
                 hash?: (Uint8Array|null);
 
-                /** Process key */
-                key?: (string|null);
+                /** Process name */
+                name?: (string|null);
 
                 /** Process nodes */
                 nodes?: (mesg.types.Process.INode[]|null);
@@ -38,8 +38,8 @@ declare namespace mesg {
                 /** Process hash. */
                 public hash: Uint8Array;
 
-                /** Process key. */
-                public key: string;
+                /** Process name. */
+                public name: string;
 
                 /** Process nodes. */
                 public nodes: mesg.types.Process.INode[];
@@ -52,6 +52,9 @@ declare namespace mesg {
 
                 /** Properties of a Node. */
                 interface INode {
+
+                    /** Node key */
+                    key?: (string|null);
 
                     /** Node result */
                     result?: (mesg.types.Process.Node.IResult|null);
@@ -78,6 +81,9 @@ declare namespace mesg {
                      */
                     constructor(properties?: mesg.types.Process.INode);
 
+                    /** Node key. */
+                    public key: string;
+
                     /** Node result. */
                     public result?: (mesg.types.Process.Node.IResult|null);
 
@@ -102,9 +108,6 @@ declare namespace mesg {
                     /** Properties of a Result. */
                     interface IResult {
 
-                        /** Result key */
-                        key?: (string|null);
-
                         /** Result instanceHash */
                         instanceHash?: (Uint8Array|null);
 
@@ -121,9 +124,6 @@ declare namespace mesg {
                          */
                         constructor(properties?: mesg.types.Process.Node.IResult);
 
-                        /** Result key. */
-                        public key: string;
-
                         /** Result instanceHash. */
                         public instanceHash: Uint8Array;
 
@@ -133,9 +133,6 @@ declare namespace mesg {
 
                     /** Properties of an Event. */
                     interface IEvent {
-
-                        /** Event key */
-                        key?: (string|null);
 
                         /** Event instanceHash */
                         instanceHash?: (Uint8Array|null);
@@ -153,9 +150,6 @@ declare namespace mesg {
                          */
                         constructor(properties?: mesg.types.Process.Node.IEvent);
 
-                        /** Event key. */
-                        public key: string;
-
                         /** Event instanceHash. */
                         public instanceHash: Uint8Array;
 
@@ -165,9 +159,6 @@ declare namespace mesg {
 
                     /** Properties of a Task. */
                     interface ITask {
-
-                        /** Task key */
-                        key?: (string|null);
 
                         /** Task instanceHash */
                         instanceHash?: (Uint8Array|null);
@@ -185,9 +176,6 @@ declare namespace mesg {
                          */
                         constructor(properties?: mesg.types.Process.Node.ITask);
 
-                        /** Task key. */
-                        public key: string;
-
                         /** Task instanceHash. */
                         public instanceHash: Uint8Array;
 
@@ -197,9 +185,6 @@ declare namespace mesg {
 
                     /** Properties of a Map. */
                     interface IMap {
-
-                        /** Map key */
-                        key?: (string|null);
 
                         /** Map outputs */
                         outputs?: (mesg.types.Process.Node.Map.IOutput[]|null);
@@ -213,9 +198,6 @@ declare namespace mesg {
                          * @param [properties] Properties to set
                          */
                         constructor(properties?: mesg.types.Process.Node.IMap);
-
-                        /** Map key. */
-                        public key: string;
 
                         /** Map outputs. */
                         public outputs: mesg.types.Process.Node.Map.IOutput[];
@@ -291,9 +273,6 @@ declare namespace mesg {
                     /** Properties of a Filter. */
                     interface IFilter {
 
-                        /** Filter key */
-                        key?: (string|null);
-
                         /** Filter conditions */
                         conditions?: (mesg.types.Process.Node.Filter.ICondition[]|null);
                     }
@@ -306,9 +285,6 @@ declare namespace mesg {
                          * @param [properties] Properties to set
                          */
                         constructor(properties?: mesg.types.Process.Node.IFilter);
-
-                        /** Filter key. */
-                        public key: string;
 
                         /** Filter conditions. */
                         public conditions: mesg.types.Process.Node.Filter.ICondition[];
@@ -594,8 +570,8 @@ declare namespace mesg {
             /** Properties of a CreateProcessRequest. */
             interface ICreateProcessRequest {
 
-                /** CreateProcessRequest key */
-                key?: (string|null);
+                /** CreateProcessRequest name */
+                name?: (string|null);
 
                 /** CreateProcessRequest nodes */
                 nodes?: (mesg.types.Process.INode[]|null);
@@ -613,8 +589,8 @@ declare namespace mesg {
                  */
                 constructor(properties?: mesg.api.ICreateProcessRequest);
 
-                /** CreateProcessRequest key. */
-                public key: string;
+                /** CreateProcessRequest name. */
+                public name: string;
 
                 /** CreateProcessRequest nodes. */
                 public nodes: mesg.types.Process.INode[];

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -5,6 +5,9 @@
 #### Breaking Changes
 #### Added
 #### Changed
+
+- Update process's compilation based on the latest API
+
 #### Fixed
 #### Removed
 

--- a/packages/cli/src/commands/process/list.ts
+++ b/packages/cli/src/commands/process/list.ts
@@ -17,7 +17,7 @@ export default class ProcessList extends Command {
     const {processes} = await this.api.process.list({})
     cli.table(processes || [], {
       hash: {header: 'HASH', get: x => x.hash ? base58.encode(x.hash) : ''},
-      key: {header: 'KEY', get: x => x.key},
+      name: {header: 'NAME', get: x => x.name},
     }, {printLine: this.log, ...flags})
     return processes || []
   }

--- a/packages/cli/src/commands/process/logs.ts
+++ b/packages/cli/src/commands/process/logs.ts
@@ -79,7 +79,7 @@ export default class ProcessLogs extends Command {
   formatResult(execution: IExecution) {
     if (!execution.instanceHash) return
     const prefix = [
-      `[${execution.stepID}]`,
+      `[${execution.nodeKey}]`,
       b58.encode(execution.instanceHash),
       this.services[b58.encode(execution.instanceHash)].sid,
       execution.taskKey,

--- a/packages/cli/src/utils/compiler.ts
+++ b/packages/cli/src/utils/compiler.ts
@@ -60,26 +60,21 @@ const nodeCompiler = async (
     defaultNodeKey?: string | null,
     instanceResolver?(object: any): Promise<hash>
   }
-) => {
+): Promise<ProcessType.mesg.types.Process.Node> => {
   const nodes = {
-    result: async (def: any, key: string, opts: any): Promise<ProcessType.mesg.types.Process.Node.IResult> => ({
-      key,
+    result: async (def: any, opts: any): Promise<ProcessType.mesg.types.Process.Node.IResult> => ({
       taskKey: def.taskKey,
       instanceHash: opts.instanceResolver ? await opts.instanceResolver(def) : def.instanceHash
     }),
-    event: async (def: any, key: string, opts: any): Promise<ProcessType.mesg.types.Process.Node.IEvent> => ({
-      key,
+    event: async (def: any, opts: any): Promise<ProcessType.mesg.types.Process.Node.IEvent> => ({
       eventKey: def.eventKey,
       instanceHash: opts.instanceResolver ? await opts.instanceResolver(def) : def.instanceHash
     }),
-    task: async (def: any, key: string, opts: any): Promise<ProcessType.mesg.types.Process.Node.ITask> => ({
-      key,
-      taskKey:
-      def.taskKey,
+    task: async (def: any, opts: any): Promise<ProcessType.mesg.types.Process.Node.ITask> => ({
+      taskKey: def.taskKey,
       instanceHash: opts.instanceResolver ? await opts.instanceResolver(def) : def.instanceHash
     }),
-    map: async (def: any, key: string, opts: any): Promise<ProcessType.mesg.types.Process.Node.IMap> => ({
-      key,
+    map: async (def: any, opts: any): Promise<ProcessType.mesg.types.Process.Node.IMap> => ({
       outputs: Object.keys(def).map(key => ({
         key,
         ...(typeof def[key] === 'object' && def[key].key  // if the value is an object containing an attribute key
@@ -94,8 +89,7 @@ const nodeCompiler = async (
           })
       }))
     }),
-    filter: async (def: any, key: string): Promise<ProcessType.mesg.types.Process.Node.IFilter> => ({
-      key,
+    filter: async (def: any): Promise<ProcessType.mesg.types.Process.Node.IFilter> => ({
       conditions: Object.keys(def.conditions).map(key => ({
         key,
         predicate: 1, // EQ
@@ -104,7 +98,8 @@ const nodeCompiler = async (
     })
   }
   return {
-    [type]: await nodes[type](def, key, opts)
+    key,
+    [type]: await nodes[type](def, opts)
   }
 }
 
@@ -147,7 +142,7 @@ export const process = async (content: Buffer, instanceResolver: (object: any) =
   }
 
   return {
-    key: definition.key,
+    name: definition.name || definition.key,
     nodes,
     edges,
   }


### PR DESCRIPTION
fix #147
dependent on https://github.com/mesg-foundation/engine/pull/1536

- [x] Update proto definition
- [x] Rename `process.key` to `process.name` (still accept the key in the yaml to not break the current one)
- [x] Move the node key in the node struct instead of the node resource struct