### PR TITLE
Expose rpc port on daemon:start

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 #### Breaking Changes
 #### Improvements
+
+- Add `rpc-port` flag to the `daemon:start` command to expose the RPC API
+
 #### Bug fixes
 
 ## [v0.1.1](https://github.com/mesg-foundation/js-sdk/releases/tag/%40mesg%2Fcli%400.1.1)

--- a/packages/cli/src/commands/daemon/start.ts
+++ b/packages/cli/src/commands/daemon/start.ts
@@ -32,6 +32,11 @@ export default class Start extends Command {
       default: 26656,
       required: true,
     }),
+    'rpc-port': flags.integer({
+      description: 'Port to interact with the RPC API',
+      default: 26657,
+      required: true,
+    }),
   }
 
   async run() {
@@ -62,6 +67,7 @@ export default class Start extends Command {
       path: flags.path,
       port: flags.port,
       p2pPort: flags['p2p-port'],
+      rpcPort: flags['rpc-port']
     })
     await eventPromise
     await this.waitForAPI()

--- a/packages/cli/src/docker-command.ts
+++ b/packages/cli/src/docker-command.ts
@@ -27,6 +27,7 @@ interface ServiceOption {
   port: number
   path: string
   p2pPort: number
+  rpcPort: number
 }
 
 export default abstract class extends Command {
@@ -128,6 +129,11 @@ export default abstract class extends Command {
           PublishMode: 'ingress',
           TargetPort: 26656,
           PublishedPort: options.p2pPort,
+        }, {
+          Protocol: 'tcp',
+          PublishMode: 'ingress',
+          TargetPort: 26657,
+          PublishedPort: options.rpcPort,
         }],
       }
     })


### PR DESCRIPTION
fix https://github.com/mesg-foundation/js-sdk/issues/159

Add `rpc-port` flag to the `daemon:start` command to expose the RPC API