### PR TITLE
Encode in base58 the hash of the service displayed in an error

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -6,6 +6,8 @@
 #### Improvements
 #### Bug fixes
 
+- [#163](https://github.com/mesg-foundation/js-sdk/pull/163) Fixes encoding of hash in not existing task error in command `service:execute`.
+
 ## [v0.1.1](https://github.com/mesg-foundation/js-sdk/releases/tag/%40mesg%2Fcli%400.1.1)
 
 #### Improvements

--- a/packages/cli/src/commands/service/execute.ts
+++ b/packages/cli/src/commands/service/execute.ts
@@ -55,7 +55,7 @@ export default class ServiceExecute extends Command {
 
     const task = service.tasks.find(x => x.key === args.TASK)
     if (!task) {
-      throw new Error(`The task ${args.TASK} does not exist in service '${service.hash}'`)
+      throw new Error(`The task ${args.TASK} does not exist in service '${base58.encode(service.hash)}'`)
     }
 
     const result = await this.execute({


### PR DESCRIPTION
Fixes https://github.com/mesg-foundation/js-sdk/issues/162:

```
➜  js-sdk git:(master) ✗ ./packages/cli/bin/run service:execute 9aMeXj2KhHdvQmrWPv9V2qYHTjr2Y8iAb87nyRPoeLvx ping --data msg=hello
 ›   Error: The task ping does not exist in service 'BLH8cqnb2YXEZPtq5nM3oHDHBNi4JXs5ekePGPLeZ1iw'
```