### PR TITLE
Access data of trigger after a filter

### DIFF
--- a/packages/compiler/CHANGELOG.md
+++ b/packages/compiler/CHANGELOG.md
@@ -6,7 +6,8 @@
 #### Improvements
 #### Bug fixes
 
-- Add more tests to compile processes, ensure multi step processes
+- [#158](https://github.com/mesg-foundation/js-sdk/pull/158) Add more tests to compile processes, ensure multi step processes
+- [#165](https://github.com/mesg-foundation/js-sdk/pull/165) Fix issue with trigger > filter > task's reference
 
 ## [v0.1.0](https://github.com/mesg-foundation/js-sdk/releases/tag/%40mesg%2Fcompiler%400.1.0)
 

--- a/packages/compiler/src/process.ts
+++ b/packages/compiler/src/process.ts
@@ -114,18 +114,17 @@ export default async (content: Buffer, instanceResolver: (object: any) => Promis
   let edges = []
 
   let previousKey: string | null = null
-  let previousKeyWithOutputs: string | null = null
   let i = 0
   for (const step of definition.steps) {
     step.key = step.key || `node-${i}`
     if (step.inputs) {
       const mapKey = `${step.key}-inputs`
-      const mapNode = await nodeCompiler('map', step.inputs, mapKey, {defaultNodeKey: previousKeyWithOutputs})
+      const mapNode = await nodeCompiler('map', step.inputs, mapKey, {defaultNodeKey: previousKey})
       nodes.push(mapNode)
       if (previousKey) {
         edges.push({src: previousKey, dst: mapKey})
       }
-      previousKeyWithOutputs = previousKey = mapKey
+      previousKey = mapKey
       i++
     }
     const type = step.type !== 'trigger'
@@ -137,9 +136,6 @@ export default async (content: Buffer, instanceResolver: (object: any) => Promis
     nodes.push(stepNode)
     if (previousKey) {
       edges.push({src: previousKey, dst: step.key})
-    }
-    if (type !== 'filter') {
-      previousKeyWithOutputs = step.key
     }
     previousKey = step.key
     i++

--- a/packages/compiler/src/process_test.ts
+++ b/packages/compiler/src/process_test.ts
@@ -4,7 +4,7 @@ import { readFileSync } from 'fs';
 import compile from './process'
 
 test('valid compilation', async (t: Test) => {
-  t.plan(112)
+  t.plan(114)
   const env = { INSTANCE_HASH: 'xxx' }
   const res = await compile(
     readFileSync('src/tests/process.yml'),
@@ -44,7 +44,7 @@ test('valid compilation', async (t: Test) => {
 
   // Test map
   t.equal(mapTask1.key, "task1-inputs")
-  t.equal(Object.keys(mapTask1.map.outputs).length, 12)
+  t.equal(Object.keys(mapTask1.map.outputs).length, 13)
   // Test constants
   t.equal(mapTask1.map.outputs["constant_str"].stringConst, "constant_str")
   t.equal(mapTask1.map.outputs["constant_null"].null, 0)
@@ -59,7 +59,7 @@ test('valid compilation', async (t: Test) => {
   t.equal(list[3].map.outputs["foo"].stringConst, "bar")
   t.equal(list[3].map.outputs["number"].doubleConst, 42)
   t.equal(list[4].ref.path.key, "dataX")
-  t.equal(list[4].ref.nodeKey, "eventTrigger")
+  t.equal(list[4].ref.nodeKey, "node-1")
   // Test map
   const inputMap = mapTask1.map.outputs["constant_map"].map.outputs
   t.equal(Object.keys(inputMap).length, 7)
@@ -73,7 +73,7 @@ test('valid compilation', async (t: Test) => {
   t.equal(inputMap["constant_list"].list.outputs[2].doubleConst, 42)
   t.equal(inputMap["constant_list"].list.outputs[3].map.outputs["foo"].stringConst, "bar")
   t.equal(inputMap["constant_list"].list.outputs[4].ref.path.key, "dataX")
-  t.equal(inputMap["constant_list"].list.outputs[4].ref.nodeKey, "eventTrigger")
+  t.equal(inputMap["constant_list"].list.outputs[4].ref.nodeKey, "node-1")
   t.equal(inputMap["constant_map"].map.outputs["constant_str"].stringConst, "constant_str")
   t.equal(inputMap["constant_map"].map.outputs["constant_null"].null, 0)
   t.equal(inputMap["constant_map"].map.outputs["constant_number"].doubleConst, 42)
@@ -83,7 +83,7 @@ test('valid compilation', async (t: Test) => {
   t.equal(inputMap["constant_map"].map.outputs["constant_list"].list.outputs[2].doubleConst, 42)
   t.equal(inputMap["constant_map"].map.outputs["constant_list"].list.outputs[3].map.outputs["foo"].stringConst, "bar")
   t.equal(inputMap["constant_map"].map.outputs["constant_list"].list.outputs[4].ref.path.key, "dataX")
-  t.equal(inputMap["constant_map"].map.outputs["constant_list"].list.outputs[4].ref.nodeKey, "eventTrigger")
+  t.equal(inputMap["constant_map"].map.outputs["constant_list"].list.outputs[4].ref.nodeKey, "node-1")
   t.equal(inputMap["constant_map"].map.outputs["ref"].ref.path.key, "dataX")
   t.equal(inputMap["constant_map"].map.outputs["ref"].ref.nodeKey, "eventTrigger")
   // Test ref
@@ -136,6 +136,10 @@ test('valid compilation', async (t: Test) => {
   t.equal(ref_list_list.path.path.path.key, null)
   t.equal(ref_list_list.path.path.path.path, null)
   t.equal(ref_list_list.path.path.path.index, 1)
+  // Test implicit ref
+  const implicit_ref = mapTask1.map.outputs["implicit_ref"].ref
+  t.equal(implicit_ref.nodeKey, "node-1")
+  t.equal(implicit_ref.path.key, "dataX")
 
   // Test task1
   t.isEquivalent(task1.task.instanceHash, Buffer.from(env.INSTANCE_HASH))

--- a/packages/compiler/src/tests/process.yml
+++ b/packages/compiler/src/tests/process.yml
@@ -70,6 +70,8 @@ steps:
       ref_list_list:
         stepKey: eventTrigger
         key: dataY[0][1]
+      implicit_ref:
+        key: dataX
   - type: task
     key: task2
     instanceHash: $(env:INSTANCE_HASH)


### PR DESCRIPTION
Fix https://github.com/mesg-foundation/js-sdk/issues/164

Because the compilation was taking the latest node **with outputs**, the reference was pointing to an ancestor but not the parent in the graph.

For filter and map, data are propagated so we should take the parent node only