### PR TITLE
Add tendermint client and service:list command

### DIFF
--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -961,6 +961,11 @@
 				"lodash": "^4.17.14"
 			}
 		},
+		"async-limiter": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
+			"integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
+		},
 		"atob": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
@@ -3106,6 +3111,11 @@
 				}
 			}
 		},
+		"int53": {
+			"version": "0.2.4",
+			"resolved": "https://registry.npmjs.org/int53/-/int53-0.2.4.tgz",
+			"integrity": "sha1-XtjXqtbFxlZ8rmmqf/xKEJ7oD4Y="
+		},
 		"into-stream": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
@@ -3784,6 +3794,14 @@
 			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
 			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
 		},
+		"json-stable-stringify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+			"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+			"requires": {
+				"jsonify": "~0.0.0"
+			}
+		},
 		"json-stringify-safe": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -3804,6 +3822,11 @@
 			"requires": {
 				"graceful-fs": "^4.1.6"
 			}
+		},
+		"jsonify": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
 		},
 		"jsonparse": {
 			"version": "0.0.5",
@@ -4692,6 +4715,14 @@
 			"dev": true,
 			"requires": {
 				"isobject": "^3.0.1"
+			}
+		},
+		"old": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/old/-/old-0.1.3.tgz",
+			"integrity": "sha1-WCTZn/xOxujFKz886VWhel+BStE=",
+			"requires": {
+				"object-assign": "^4.1.0"
 			}
 		},
 		"once": {
@@ -6039,6 +6070,11 @@
 			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
 			"dev": true
 		},
+		"supercop.js": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/supercop.js/-/supercop.js-2.0.1.tgz",
+			"integrity": "sha1-H8/p/F/25CrvTjaDY2yMuJFZSxg="
+		},
 		"supports-color": {
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -6100,6 +6136,39 @@
 				"readable-stream": "^2.3.0",
 				"to-buffer": "^1.1.1",
 				"xtend": "^4.0.0"
+			}
+		},
+		"tendermint": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/tendermint/-/tendermint-4.0.8.tgz",
+			"integrity": "sha512-K9lnePVrKxRj2ju47NVaDgbXMvkIOcfS+XXukVnyoUztEj8hcgu2Bfe6CB6O1R+FyjOu83tB+9nL8+jy+J05ZQ==",
+			"requires": {
+				"axios": "^0.19.0",
+				"camelcase": "^4.0.0",
+				"create-hash": "^1.1.3",
+				"debug": "^3.1.0",
+				"json-stable-stringify": "^1.0.1",
+				"ndjson": "^1.5.0",
+				"old": "^0.1.3",
+				"pumpify": "^1.3.5",
+				"supercop.js": "^2.0.1",
+				"varstruct": "^6.1.1",
+				"websocket-stream": "^5.1.1"
+			},
+			"dependencies": {
+				"camelcase": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+				},
+				"debug": {
+					"version": "3.2.6",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				}
 			}
 		},
 		"test-exclude": {
@@ -6408,6 +6477,11 @@
 				"source-map": "~0.6.1"
 			}
 		},
+		"ultron": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
+			"integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
+		},
 		"union-value": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
@@ -6534,6 +6608,28 @@
 			"resolved": "https://registry.npmjs.org/varint/-/varint-5.0.0.tgz",
 			"integrity": "sha1-2Ca4n3SQcy+rwMDtaT7Uddyynr8="
 		},
+		"varstruct": {
+			"version": "6.1.3",
+			"resolved": "https://registry.npmjs.org/varstruct/-/varstruct-6.1.3.tgz",
+			"integrity": "sha512-4l1Q7uxrVUBZXsMcb2cakrZL6gd4G+Ykn/m9cGnT4EY8iRBPkxOxKVDwOnL9AsIPKmREBx5BDqjfNMKKP6Zy2w==",
+			"requires": {
+				"int53": "^0.2.4",
+				"safe-buffer": "^5.1.1"
+			}
+		},
+		"websocket-stream": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/websocket-stream/-/websocket-stream-5.5.0.tgz",
+			"integrity": "sha512-EXy/zXb9kNHI07TIMz1oIUIrPZxQRA8aeJ5XYg5ihV8K4kD1DuA+FY6R96HfdIHzlSzS8HiISAfrm+vVQkZBug==",
+			"requires": {
+				"duplexify": "^3.5.1",
+				"inherits": "^2.0.1",
+				"readable-stream": "^2.3.3",
+				"safe-buffer": "^5.1.2",
+				"ws": "^3.2.0",
+				"xtend": "^4.0.0"
+			}
+		},
 		"which": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
@@ -6640,6 +6736,23 @@
 					"requires": {
 						"is-plain-obj": "^2.0.0"
 					}
+				}
+			}
+		},
+		"ws": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
+			"integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+			"requires": {
+				"async-limiter": "~1.0.0",
+				"safe-buffer": "~5.1.0",
+				"ultron": "~1.1.0"
+			},
+			"dependencies": {
+				"safe-buffer": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 				}
 			}
 		},

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -56,6 +56,7 @@
     "node-docker-api": "^1.1.22",
     "rimraf": "^3.0.0",
     "tar": "^4.4.11",
+    "tendermint": "^4.0.8",
     "tslib": "^1.10.0",
     "uuid": "^3.3.3",
     "validator": "^11.1.0"

--- a/packages/cli/src/commands/service/list.ts
+++ b/packages/cli/src/commands/service/list.ts
@@ -14,7 +14,8 @@ export default class ServiceList extends Command {
 
   async run(): Promise<IInstance[]> {
     const {flags} = this.parse(ServiceList)
-    const [{services}, {instances}, {runners}] = await Promise.all([
+
+    const [services, instances, runners] = await Promise.all([
       this.api.service.list({}),
       this.api.instance.list({}),
       this.api.runner.list({}),

--- a/packages/cli/src/tendermint.d.ts
+++ b/packages/cli/src/tendermint.d.ts
@@ -1,0 +1,1 @@
+declare module 'tendermint';


### PR DESCRIPTION
This is an experimentation using tendermint.

The goal is to use the CLi as a tendermint client for all the basic queries/transactions. This might be useful as a few "unsafe" api in the engine could be removed (all the write apis).

For now it's only the `service:list` command that works with the pr https://github.com/mesg-foundation/engine/pull/1609.

I can continue the work if we decide to move forward on this.