### PR TITLE
Fix issue when a docker service starts with engine

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -6,7 +6,7 @@
 #### Improvements
 #### Bug fixes
 
-- [](https://github.com/mesg-foundation/js-sdk/pull/) Fix docker filtering issue on docker services prefixed with "engine"
+- [#171](https://github.com/mesg-foundation/js-sdk/pull/171) Fix docker filtering issue on docker services prefixed with "engine"
 
 ## [v0.2.0](https://github.com/mesg-foundation/js-sdk/releases/tag/%40mesg%2Fcli%400.2.0)
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -6,6 +6,8 @@
 #### Improvements
 #### Bug fixes
 
+- [](https://github.com/mesg-foundation/js-sdk/pull/) Fix docker filtering issue on docker services prefixed with "engine"
+
 ## [v0.2.0](https://github.com/mesg-foundation/js-sdk/releases/tag/%40mesg%2Fcli%400.2.0)
 
 #### Improvements

--- a/packages/cli/src/docker-command.ts
+++ b/packages/cli/src/docker-command.ts
@@ -42,9 +42,12 @@ export default abstract class extends Command {
   private readonly docker: Docker = new Docker(null)
 
   async listServices(options: ListOption) {
-    return this.docker.service.list({
+    // docker service ls --filter doesn't do an exact match https://github.com/moby/moby/issues/32985
+    const res = await this.docker.service.list({
       filters: {name: [options.name]}
     })
+    return res
+      .filter(x => (x.data as any)['Spec']['Name'] === options.name)
   }
 
   async waitForEvent(matchFilter: (event: Event) => boolean) {


### PR DESCRIPTION
Fix https://github.com/mesg-foundation/js-sdk/issues/141

Docker doesn't support the exact match on their filters for the services https://github.com/moby/moby/issues/32985.

Here is a workaround to make sure that we only fetch services that have the exact match.