### PR TITLE
Use engine with version 0.19 by default

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 #### Breaking Changes
 #### Improvements
+
+- [#178](https://github.com/mesg-foundation/js-sdk/pull/178) Start the engine 0.19 version by default
+
 #### Bug fixes
 
 - [#171](https://github.com/mesg-foundation/js-sdk/pull/171) Fix docker filtering issue on docker services prefixed with "engine"

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -1,3 +1,3 @@
 export default {
-  engine: 'v0.18'
+  engine: 'v0.19'
 }


### PR DESCRIPTION
Command `mesg-cli daemon:start` will start the engine v0.19 by default