### PR TITLE
Migrate to LCD server

### DIFF
--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 #### Breaking Changes
 #### Improvements
+
+- [#179](https://github.com/mesg-foundation/js-sdk/pull/179) Add LCD API for all reading (execution, instance, ownership, process, runner, service)
+- [#179](https://github.com/mesg-foundation/js-sdk/pull/179) Migrate resolver to use LCD server
+
 #### Bug fixes
 
 ## [v0.2.0](https://github.com/mesg-foundation/js-sdk/releases/tag/%40mesg%2Fapi%400.2.0)

--- a/packages/api/package-lock.json
+++ b/packages/api/package-lock.json
@@ -122,6 +122,16 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.6.tgz",
       "integrity": "sha512-FjsYUPzEJdGXjwKqSpE0/9QEh6kzhTAeObA54rn6j3rR4C/mzpI9L0KNfoeASSPMMdxIsoJuCLDWcM/rVjIsSA=="
     },
+    "@types/node-fetch": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.5.tgz",
+      "integrity": "sha512-IWwjsyYjGw+em3xTvWVQi5MgYKbRs0du57klfTaZkv/B24AEQ/p/IopNeqIYNy3EsfHOpg8ieQSDomPcsYMHpA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      }
+    },
     "@types/sinon": {
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-7.5.0.tgz",
@@ -162,6 +172,12 @@
         "colour": "~0.7.1",
         "optjs": "~3.2.2"
       }
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -233,6 +249,15 @@
       "resolved": "https://registry.npmjs.org/colour/-/colour-0.7.1.tgz",
       "integrity": "sha1-nLFpkX7F0SwHNtPoaFdG3xyt93g="
     },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -263,6 +288,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
       "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
+      "dev": true
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
     },
     "diff": {
@@ -307,6 +338,17 @@
       "dev": true,
       "requires": {
         "is-callable": "^1.1.3"
+      }
+    },
+    "form-data": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
+      "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+      "dev": true,
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
       }
     },
     "fs.realpath": {
@@ -897,6 +939,21 @@
       "integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==",
       "dev": true
     },
+    "mime-db": {
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
+      "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ==",
+      "dev": true
+    },
+    "mime-types": {
+      "version": "2.1.26",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
+      "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
+      "dev": true,
+      "requires": {
+        "mime-db": "1.43.0"
+      }
+    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -935,6 +992,11 @@
         "lolex": "^4.1.0",
         "path-to-regexp": "^1.7.0"
       }
+    },
+    "node-fetch": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
     },
     "number-is-nan": {
       "version": "1.0.1",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -42,6 +42,7 @@
     "@grpc/proto-loader": "^0.5.3",
     "base-x": "^3.0.7",
     "grpc": "^1.24.2",
+    "node-fetch": "^2.6.0",
     "protobufjs": "^6.8.8"
   }
 }

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -30,6 +30,7 @@
   "devDependencies": {
     "@types/long": "^4.0.0",
     "@types/node": "^12.12.6",
+    "@types/node-fetch": "^2.5.5",
     "@types/sinon": "^7.5.0",
     "@types/tape": "^4.2.33",
     "ncp": "^2.0.0",

--- a/packages/api/src/account-lcd.ts
+++ b/packages/api/src/account-lcd.ts
@@ -1,5 +1,9 @@
-import { ICoin } from './transaction'
 import LCDClient from './util/lcd'
+
+export type ICoin = {
+  denom: 'atto',
+  amount: string
+}
 
 export type IAccount = {
   address: string

--- a/packages/api/src/account-lcd.ts
+++ b/packages/api/src/account-lcd.ts
@@ -1,0 +1,19 @@
+import { ICoin } from './transaction'
+import LCDClient from './util/lcd'
+
+export type IAccount = {
+  address: string
+  coins: ICoin[]
+  public_key: string
+  account_number: number
+  sequence: number
+}
+
+export default class Account extends LCDClient {
+
+  async get(address: string): Promise<IAccount> {
+    const account = (await this.query(`/auth/accounts/${address}`)).result.value
+    if (!account.address) account.address = address
+    return account
+  }
+}

--- a/packages/api/src/execution-lcd.ts
+++ b/packages/api/src/execution-lcd.ts
@@ -31,6 +31,6 @@ export default class Execution extends LCDClient {
   }
 
   async list(): Promise<IExecution[]> {
-    return (await this.query(`/execution/list`)).result
+    return (await this.query(`/execution/list`)).result || []
   }
 }

--- a/packages/api/src/execution-lcd.ts
+++ b/packages/api/src/execution-lcd.ts
@@ -1,0 +1,36 @@
+import LCDClient from './util/lcd'
+
+export enum Status {
+  Unknown = 0,
+  Created = 1,
+  InProgress = 2,
+  Completed = 3,
+  Failed = 4
+}
+
+export type IExecution = {
+  hash: string;
+  parentHash?: string;
+  eventHash?: string;
+  status: Status;
+  instanceHash: string;
+  taskKey: string;
+  inputs?: any;
+  outputs?: any;
+  error?: (string | null);
+  tags?: (string[] | null);
+  processHash?: (string | null);
+  nodeKey?: (string | null);
+  executorHash: string;
+}
+
+export default class Execution extends LCDClient {
+
+  async get(hash: string): Promise<IExecution> { 
+    return (await this.query(`/execution/get/${hash}`)).result
+  }
+
+  async list(): Promise<IExecution[]> {
+    return (await this.query(`/execution/list`)).result
+  }
+}

--- a/packages/api/src/instance-lcd.ts
+++ b/packages/api/src/instance-lcd.ts
@@ -1,0 +1,18 @@
+import LCDClient from './util/lcd'
+
+export type IInstance = {
+  hash: string;
+  serviceHash: string;
+  envHash: string;
+}
+
+export default class Instance extends LCDClient {
+
+  async get(hash: string): Promise<IInstance> {
+    return (await this.query(`/instance/get/${hash}`)).result
+  }
+
+  async list(filter?: { serviceHash?: string }): Promise<IInstance[]> {
+    return (await this.query(`/instance/list`, filter)).result
+  }
+}

--- a/packages/api/src/instance-lcd.ts
+++ b/packages/api/src/instance-lcd.ts
@@ -13,6 +13,8 @@ export default class Instance extends LCDClient {
   }
 
   async list(filter?: { serviceHash?: string }): Promise<IInstance[]> {
-    return (await this.query(`/instance/list`, filter)).result || []
+    let instances: IInstance[] = (await this.query(`/instance/list`)).result || []
+    if (filter && filter.serviceHash) instances = instances.filter(x => x.serviceHash === filter.serviceHash)
+    return instances
   }
 }

--- a/packages/api/src/instance-lcd.ts
+++ b/packages/api/src/instance-lcd.ts
@@ -13,6 +13,6 @@ export default class Instance extends LCDClient {
   }
 
   async list(filter?: { serviceHash?: string }): Promise<IInstance[]> {
-    return (await this.query(`/instance/list`, filter)).result
+    return (await this.query(`/instance/list`, filter)).result || []
   }
 }

--- a/packages/api/src/lcd.ts
+++ b/packages/api/src/lcd.ts
@@ -1,13 +1,16 @@
 import Service from './service-lcd'
 import Instance from './instance-lcd'
+import Runner from './runner-lcd'
 
 class API {
   service: Service
   instance: Instance
-  
+  runner: Runner
+
   constructor(endpoint: string = "http://localhost:1317") {
     this.service = new Service(endpoint)
     this.instance = new Instance(endpoint)
+    this.runner = new Runner(endpoint)
   }
 }
 

--- a/packages/api/src/lcd.ts
+++ b/packages/api/src/lcd.ts
@@ -1,0 +1,11 @@
+import ServiceLCD from './service-lcd'
+
+class API {
+  service: ServiceLCD
+  constructor(endpoint: string = "http://localhost:1317") {
+    this.service = new ServiceLCD(endpoint)
+  }
+}
+
+export default API;
+(module).exports = API;

--- a/packages/api/src/lcd.ts
+++ b/packages/api/src/lcd.ts
@@ -3,6 +3,7 @@ import Instance from './instance-lcd'
 import Runner from './runner-lcd'
 import Process from './process-lcd'
 import Execution from './execution-lcd'
+import Ownership from './ownership'
 
 class API {
   service: Service
@@ -10,6 +11,7 @@ class API {
   runner: Runner
   process: Process
   execution: Execution
+  ownership: Ownership
 
   constructor(endpoint: string = "http://localhost:1317") {
     this.service = new Service(endpoint)
@@ -17,6 +19,7 @@ class API {
     this.runner = new Runner(endpoint)
     this.process = new Process(endpoint)
     this.execution = new Execution(endpoint)
+    this.ownership = new Ownership(endpoint)
   }
 }
 

--- a/packages/api/src/lcd.ts
+++ b/packages/api/src/lcd.ts
@@ -2,18 +2,21 @@ import Service from './service-lcd'
 import Instance from './instance-lcd'
 import Runner from './runner-lcd'
 import Process from './process-lcd'
+import Execution from './execution-lcd'
 
 class API {
   service: Service
   instance: Instance
   runner: Runner
   process: Process
+  execution: Execution
 
   constructor(endpoint: string = "http://localhost:1317") {
     this.service = new Service(endpoint)
     this.instance = new Instance(endpoint)
     this.runner = new Runner(endpoint)
     this.process = new Process(endpoint)
+    this.execution = new Execution(endpoint)
   }
 }
 

--- a/packages/api/src/lcd.ts
+++ b/packages/api/src/lcd.ts
@@ -1,9 +1,13 @@
-import ServiceLCD from './service-lcd'
+import Service from './service-lcd'
+import Instance from './instance-lcd'
 
 class API {
-  service: ServiceLCD
+  service: Service
+  instance: Instance
+  
   constructor(endpoint: string = "http://localhost:1317") {
-    this.service = new ServiceLCD(endpoint)
+    this.service = new Service(endpoint)
+    this.instance = new Instance(endpoint)
   }
 }
 

--- a/packages/api/src/lcd.ts
+++ b/packages/api/src/lcd.ts
@@ -3,7 +3,8 @@ import Instance from './instance-lcd'
 import Runner from './runner-lcd'
 import Process from './process-lcd'
 import Execution from './execution-lcd'
-import Ownership from './ownership'
+import Ownership from './ownership-lcd'
+import Account from './account-lcd'
 
 class API {
   service: Service
@@ -12,6 +13,7 @@ class API {
   process: Process
   execution: Execution
   ownership: Ownership
+  account: Account
 
   constructor(endpoint: string = "http://localhost:1317") {
     this.service = new Service(endpoint)
@@ -20,6 +22,7 @@ class API {
     this.process = new Process(endpoint)
     this.execution = new Execution(endpoint)
     this.ownership = new Ownership(endpoint)
+    this.account = new Account(endpoint)
   }
 }
 

--- a/packages/api/src/lcd.ts
+++ b/packages/api/src/lcd.ts
@@ -1,16 +1,19 @@
 import Service from './service-lcd'
 import Instance from './instance-lcd'
 import Runner from './runner-lcd'
+import Process from './process-lcd'
 
 class API {
   service: Service
   instance: Instance
   runner: Runner
+  process: Process
 
   constructor(endpoint: string = "http://localhost:1317") {
     this.service = new Service(endpoint)
     this.instance = new Instance(endpoint)
     this.runner = new Runner(endpoint)
+    this.process = new Process(endpoint)
   }
 }
 

--- a/packages/api/src/lcd.ts
+++ b/packages/api/src/lcd.ts
@@ -15,7 +15,7 @@ class API {
   ownership: Ownership
   account: Account
 
-  constructor(endpoint: string = "http://localhost:1317") {
+  constructor(endpoint: string) {
     this.service = new Service(endpoint)
     this.instance = new Instance(endpoint)
     this.runner = new Runner(endpoint)

--- a/packages/api/src/lcd.ts
+++ b/packages/api/src/lcd.ts
@@ -15,7 +15,7 @@ class API {
   ownership: Ownership
   account: Account
 
-  constructor(endpoint: string) {
+  constructor(endpoint?: string) {
     this.service = new Service(endpoint)
     this.instance = new Instance(endpoint)
     this.runner = new Runner(endpoint)

--- a/packages/api/src/ownership-lcd.ts
+++ b/packages/api/src/ownership-lcd.ts
@@ -17,6 +17,6 @@ export type IOwnership = {
 export default class Ownership extends LCDClient {
   
   async list(): Promise<IOwnership[]> {
-    return (await this.query(`/ownership/list`)).result
+    return (await this.query(`/ownership/list`)).result || []
   }
 }

--- a/packages/api/src/ownership-lcd.ts
+++ b/packages/api/src/ownership-lcd.ts
@@ -1,0 +1,22 @@
+import LCDClient from './util/lcd'
+
+export enum Resource {
+  None = 0,
+  Service = 1,
+  Process = 2,
+  Runner = 3,
+}
+
+export type IOwnership = {
+  hash: string;
+  owner: string;
+  resourceHash: string;
+  resource: Resource;
+}
+
+export default class Ownership extends LCDClient {
+  
+  async list(): Promise<IOwnership[]> {
+    return (await this.query(`/ownership/list`)).result
+  }
+}

--- a/packages/api/src/process-lcd.ts
+++ b/packages/api/src/process-lcd.ts
@@ -1,0 +1,48 @@
+import * as ProcessType from './typedef/process'
+import LCDClient from './util/lcd'
+
+export type IResult = {
+  instanceHash: string;
+  taskKey: string;
+}
+
+export type IEvent = {
+  instanceHash: string;
+  eventKey: string;
+}
+
+export type ITask = {
+  instanceHash: string;
+  taskKey: string;
+}
+
+export type INode = {
+  key: string;
+  result?: IResult | null;
+  event?: IEvent | null;
+  task?: ITask | null;
+  map?: ProcessType.mesg.types.Process.Node.IMap | null;
+  filter?: ProcessType.mesg.types.Process.Node.IFilter | null;
+}
+
+export type IProcess = {
+  name: string;
+  nodes: INode[];
+  edges: ProcessType.mesg.types.Process.IEdge[];
+}
+
+export type IProcessRequest = {
+  name: string;
+  nodes: INode[];
+  edges: ProcessType.mesg.types.Process.IEdge[];
+}
+
+export default class Process extends LCDClient {
+  async get(hash: string): Promise<IProcess> {
+    return (await this.query(`/process/get/${hash}`)).result
+  }
+
+  async list(): Promise<IProcess[]> {
+    return (await this.query('/process/list')).result || []
+  }
+}

--- a/packages/api/src/process-lcd.ts
+++ b/packages/api/src/process-lcd.ts
@@ -16,16 +16,51 @@ export type ITask = {
   taskKey: string;
 }
 
+export type IMap = any
+export type IFilter = any
+
+export type IResultType = {
+  type: 'mesg.types.Process_Node_Result_';
+  value: {
+    result: IResult;
+  }
+}
+
+export type IEventType = {
+  type: 'mesg.types.Process_Node_Event_';
+  value: {
+    event: IEvent;
+  }
+}
+
+export type ITaskType = {
+  type: 'mesg.types.Process_Node_Task_';
+  value: {
+    task: ITask;
+  }
+}
+
+export type IMapType = {
+  type: 'mesg.types.Process_Node_Map_';
+  value: {
+    map: IMap;
+  }
+}
+
+export type IFilterType = {
+  type: 'mesg.types.Process_Node_Filter_';
+  value: {
+    filter: IFilter;
+  }
+}
+
 export type INode = {
   key: string;
-  result?: IResult | null;
-  event?: IEvent | null;
-  task?: ITask | null;
-  map?: ProcessType.mesg.types.Process.Node.IMap | null;
-  filter?: ProcessType.mesg.types.Process.Node.IFilter | null;
+  Type: IEventType | IResultType | ITaskType | IMapType | IFilterType;
 }
 
 export type IProcess = {
+  hash?: string;
   name: string;
   nodes: INode[];
   edges: ProcessType.mesg.types.Process.IEdge[];

--- a/packages/api/src/runner-lcd.ts
+++ b/packages/api/src/runner-lcd.ts
@@ -12,6 +12,9 @@ export default class Runner extends LCDClient {
   }
 
   async list(filter?: { instanceHash?: string | null, address?: string | null }): Promise<IRunner[]> {
-    return (await this.query('/runner/list', filter)).result || []
+    let runners: IRunner[] = (await this.query('/runner/list')).result || []
+    if (filter && filter.instanceHash) runners = runners.filter(x => x.instanceHash === filter.instanceHash)
+    if (filter && filter.address) runners = runners.filter(x => x.address === filter.address)
+    return runners
   }
 }

--- a/packages/api/src/runner-lcd.ts
+++ b/packages/api/src/runner-lcd.ts
@@ -1,0 +1,17 @@
+import LCDClient from './util/lcd'
+
+export type IRunner = {
+  hash: string;
+  address: string;
+  instanceHash?: string | null;
+}
+
+export default class Runner extends LCDClient {
+  async get(hash: string): Promise<IRunner> {
+    return (await this.query(`/runner/get/${hash}`)).result
+  }
+
+  async list(filter?: { instanceHash?: string | null, address?: string | null }): Promise<IRunner[]> {
+    return (await this.query('/runner/list', filter)).result || []
+  }
+}

--- a/packages/api/src/service-lcd.ts
+++ b/packages/api/src/service-lcd.ts
@@ -1,0 +1,31 @@
+import * as ServiceType from './typedef/service'
+import LCDClient from './util/lcd'
+
+export type IService = {
+  hash?: string;
+  sid?: string | null;
+  name?: string | null;
+  description?: string | null;
+  configuration: ServiceType.mesg.types.Service.IConfiguration;
+  tasks?: ServiceType.mesg.types.Service.ITask[] | null;
+  events?: ServiceType.mesg.types.Service.IEvent[] | null;
+  dependencies?: ServiceType.mesg.types.Service.IDependency[] | null;
+  repository?: string | null;
+  source?: string | null;
+}
+
+export default class ServiceLCD extends LCDClient {
+
+  // async get(hash: hash): Promise<IServiceLCD> {
+  // }
+
+  // async exists(hash: hash): Promise<boolean> {
+  // }
+
+  // async hash(request: ServiceHashInputs): Promise<hash> {
+  // }
+
+  async list(): Promise<IService[]> {
+    return (await this.query('/service/list')).result || []
+  }
+}

--- a/packages/api/src/service-lcd.ts
+++ b/packages/api/src/service-lcd.ts
@@ -16,14 +16,17 @@ export type IService = {
 
 export default class ServiceLCD extends LCDClient {
 
-  // async get(hash: hash): Promise<IServiceLCD> {
-  // }
+  async get(hash: string): Promise<IService> {
+    return (await this.query(`/service/get/${hash}`)).result
+  }
 
-  // async exists(hash: hash): Promise<boolean> {
-  // }
+  async exists(hash: string): Promise<boolean> {
+    return (await this.query(`/service/exist/${hash}`)).result
+  }
 
-  // async hash(request: ServiceHashInputs): Promise<hash> {
-  // }
+  async hash(request: IService): Promise<string> {
+    return (await this.query(`/service/hash`, request, 'POST')).result
+  }
 
   async list(): Promise<IService[]> {
     return (await this.query('/service/list')).result || []

--- a/packages/api/src/util/lcd.ts
+++ b/packages/api/src/util/lcd.ts
@@ -1,0 +1,50 @@
+import fetch from 'node-fetch'
+import { resolve } from 'url'
+
+export default class LCDClient {
+  private _endpoint: string
+
+  constructor(endpoint: string = "http://localhost:1317") {
+    this._endpoint = endpoint
+  }
+
+  protected async query(path: string, data?: any, method: string = 'GET'): Promise<{ height: string, result: any }> {
+    const result = method === 'GET'
+      ? await this.getRequest(path, data)
+      : await this.postRequest(path, data)
+    if (result.error) throw new Error(result.error)
+    return result
+  }
+
+  protected async getRequest(path: string, params?: any): Promise<any> {
+    const response = await fetch(this.fullEndpoint(path, params), {
+      headers: {
+        "Content-Type": "application/json"
+      }
+    })
+    return response.json()
+  }
+
+  protected async postRequest(path: string, data?: Object): Promise<any> {
+    const response = await fetch(this.fullEndpoint(path), {
+      method: 'POST',
+      body: JSON.stringify(data),
+      headers: {
+        "Content-Type": "application/json"
+      }
+    })
+    return response.json()
+  }
+
+  private fullEndpoint(path: string, params?: any): string {
+    const encodedParams = Object.keys(params || {})
+      .map((key) => `${key}=${params[key]}`)
+      .join('&')
+    return [
+      resolve(this._endpoint, path),
+      encodedParams
+    ]
+      .filter(x => x)
+      .join('?')
+  }
+}

--- a/packages/api/src/util/resolve.ts
+++ b/packages/api/src/util/resolve.ts
@@ -1,22 +1,22 @@
-import { hash, IApi } from "../types";
+import API from '../lcd'
 
-const _resolutionTable: Map<string, hash> = new Map()
+const _resolutionTable: Map<string, string> = new Map()
 
 // TODO: should we keep those functions??
 // returns an instanceHash based on an sid
 // throw an error if the sid doesn't exists or have if it has more or less than one instance running
-export const resolveSID = async (api: IApi, sid: string): Promise<hash> => {
+export const resolveSID = async (api: API, sid: string): Promise<string> => {
   if (_resolutionTable.has(sid)) return _resolutionTable.get(sid)
 
   // TODO: add filter directly on list API
-  const { services } = await api.service.list({})
+  const services = await api.service.list()
   const matching = services.filter(x => x.sid === sid)
   if (matching.length === 0) throw new Error(`cannot resolve ${sid}`)
   if (matching.length > 1) throw new Error(`multiple services resolve ${sid}`)
   const service = matching[0]
 
   // find matching instances
-  const { instances } = await api.instance.list({ filter: { serviceHash: service.hash }})
+  const instances = await api.instance.list({ serviceHash: service.hash })
   if (!instances || instances.length === 0) throw new Error(`no instances running for the service ${service.sid}`)
   if (instances.length > 1) throw new Error(`multiple instances running for the service ${service.sid}`)
 
@@ -24,28 +24,28 @@ export const resolveSID = async (api: IApi, sid: string): Promise<hash> => {
   return _resolutionTable.get(sid)
 }
 
-const _resolutionTableRunners: Map<string, hash> = new Map()
+const _resolutionTableRunners: Map<string, string> = new Map()
 
 // returns a Runner Hash based on an sid
 // throw an error if the sid doesn't exists or have if there is not exactly one runner running
-export const resolveSIDRunner = async (api: IApi, sid: string): Promise<hash> => {
+export const resolveSIDRunner = async (api: API, sid: string): Promise<string> => {
   if (_resolutionTableRunners.has(sid)) return _resolutionTableRunners.get(sid)
 
   // TODO: add filter directly on list API
-  const { services } = await api.service.list({})
+  const services = await api.service.list()
   const matching = services.filter(x => x.sid === sid)
   if (matching.length === 0) throw new Error(`cannot resolve ${sid}`)
   if (matching.length > 1) throw new Error(`multiple services resolve ${sid}`)
   const service = matching[0]
 
   // find matching instances
-  const { instances } = await api.instance.list({ filter: { serviceHash: service.hash }})
+  const instances = await api.instance.list({ serviceHash: service.hash })
   if (!instances || instances.length === 0) throw new Error(`no instances for the service ${service.sid}`)
   if (instances.length > 1) throw new Error(`multiple instances for the service ${service.sid}`)
   const instance = instances[0]
 
   // find matching runners
-  const { runners } = await api.runner.list({ filter: { instanceHash: instance.hash }})
+  const runners = await api.runner.list({ instanceHash: instance.hash })
   if (!runners || runners.length === 0) throw new Error(`no runners for the service ${service.sid}`)
   if (runners.length > 1) throw new Error(`multiple runners for the service ${service.sid}`)
   const runner = runners[0]

--- a/packages/api/src/util/resolve_test.ts
+++ b/packages/api/src/util/resolve_test.ts
@@ -2,17 +2,19 @@ import { Test } from 'tape'
 import test from 'tape'
 import * as sinon from 'sinon'
 import { resolveSID } from './resolve'
-import Api from '../mock'
+import Api from '../lcd'
+import { IService } from '../service-lcd'
+import { IInstance } from '../instance-lcd'
 
-const instances = [{ hash: Buffer.from('instancehash'), serviceHash: Buffer.from('servicehash') }]
-const services = [{ hash: Buffer.from('servicehash'), sid: 'servicesid' }]
+const instances: IInstance[] = [{ hash: 'instancehash', serviceHash: 'servicehash', envHash: '' }]
+const services: IService[] = [{ hash: 'servicehash', sid: 'servicesid', configuration: {} }]
 
 test('resolve service invalid', async function (t: Test) {
   t.plan(1);
-  const api = Api('')
+  const api = new Api()
   const sid = "invalid"
   sinon.stub(api.instance, 'get').callsFake(() => { throw new Error("not found") })
-  sinon.stub(api.service, 'list').callsFake(() => (Promise.resolve({ services })))
+  sinon.stub(api.service, 'list').callsFake(() => Promise.resolve(services))
   try {
     await resolveSID(api, sid)
   } catch (e) {
@@ -22,21 +24,21 @@ test('resolve service invalid', async function (t: Test) {
 
 test('resolve service by sid', async function (t: Test) {
   t.plan(1);
-  const api = Api('')
+  const api = new Api()
   const sid = "servicesid"
   sinon.stub(api.instance, 'get').callsFake(() => { throw new Error("not found") })
-  sinon.stub(api.service, 'list').callsFake(() => (Promise.resolve({ services })))
-  sinon.stub(api.instance, 'list').callsFake(() => (Promise.resolve({ instances })))
+  sinon.stub(api.service, 'list').callsFake(() => Promise.resolve(services))
+  sinon.stub(api.instance, 'list').callsFake(() => Promise.resolve(instances))
   const instanceHash = await resolveSID(api, sid)
   t.equal(instanceHash, instances[0].hash)
 });
 
 test('resolve service by sid (multiple)', async function (t: Test) {
   t.plan(1);
-  const api = Api('')
+  const api = new Api()
   const sid = "multiplesid"
   sinon.stub(api.instance, 'get').callsFake(() => { throw new Error("not found") })
-  sinon.stub(api.service, 'list').callsFake(() => (Promise.resolve({ services: [{ sid }, { sid }] })))
+  sinon.stub(api.service, 'list').callsFake(() => Promise.resolve([{ sid, configuration: {} }, { sid, configuration: {} }]))
   try {
     await resolveSID(api, sid)
   } catch (e) {

--- a/packages/application/CHANGELOG.md
+++ b/packages/application/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## [Unreleased](https://github.com/mesg-foundation/js-sdk/releases/tag/%40mesg%2Fapplication%40X.X.X)
 
 #### Breaking Changes
+
+- [#179](https://github.com/mesg-foundation/js-sdk/pull/179) Resolver now returns string version of the runner/service hash (instead of a buffer) + migration to use the lcd server
+
 #### Improvements
 #### Bug fixes
 

--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -5,11 +5,13 @@ import { checkStreamReady, errNoStatus, Stream } from '@mesg/api/lib/util/grpc'
 import API from '@mesg/api';
 import { IApi } from '@mesg/api/lib/types';
 import { resolveSID, resolveSIDRunner } from '@mesg/api/lib/util/resolve'
-import { hash, ExecutionStatus } from '@mesg/api/lib/types';
+import { ExecutionStatus } from '@mesg/api/lib/types';
 import { EventStreamInputs, IEvent } from '@mesg/api/lib/event';
 import { ExecutionStreamInputs, IExecution, ExecutionCreateInputs, ExecutionCreateOutputs } from '@mesg/api/lib/execution';
+import LCD from '@mesg/api/lib/lcd';
 
 const defaultEndpoint = 'localhost:50052'
+const defaultLCDEndpoint = 'http://localhost:1317'
 
 type Options = {
   api?: IApi
@@ -18,9 +20,12 @@ type Options = {
 class Application {
   // api gives access to low level gRPC calls.
   private api: IApi
+  // api gives access to lcd api.
+  private lcd: LCD
 
-  constructor(_api?: IApi) {
+  constructor(_api?: IApi, _lcd?: LCD) {
     this.api = _api || new API(defaultEndpoint);
+    this.lcd = _lcd || new LCD(defaultLCDEndpoint);
   }
 
   decodeData(data: mesg.protobuf.IStruct) {
@@ -31,12 +36,12 @@ class Application {
     return encode(data)
   }
 
-  async resolve(sid: string): Promise<hash> {
-    return resolveSID(this.api, sid)
+  async resolve(sid: string): Promise<string> {
+    return resolveSID(this.lcd, sid)
   }
 
-  async resolveRunner(sid: string): Promise<hash> {
-    return resolveSIDRunner(this.api, sid)
+  async resolveRunner(sid: string): Promise<string> {
+    return resolveSIDRunner(this.lcd, sid)
   }
 
   listenEvent(request: EventStreamInputs): Stream<IEvent> {

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 #### Breaking Changes
 #### Improvements
+
+- [#179](https://github.com/mesg-foundation/js-sdk/pull/179) Add new flag `lcd-port` to all command to configure the port of the LCD server.
+- [#179](https://github.com/mesg-foundation/js-sdk/pull/179) Use LCD server for all reading (`process:compile`, `process:detail`, `process:list`, `process:logs`, `service:detail`, `service:dev`, `service:execute`, `service:list`, `service:logs`, `service:start`, `service:stop`)
+
 #### Bug fixes
 
 ## [v0.3.0](https://github.com/mesg-foundation/js-sdk/releases/tag/%40mesg%2Fcli%400.3.0)

--- a/packages/cli/src/commands/process/compile.ts
+++ b/packages/cli/src/commands/process/compile.ts
@@ -76,7 +76,7 @@ export default class ProcessCompile extends Command {
     if (!exists) {
       const resp = await this.api.service.create(definition)
       if (!resp.hash) throw new Error('invalid hash')
-      if (resp.hash.toString() !== hash.toString()) throw new Error('invalid hash')
+      if (base58.encode(resp.hash) !== hash) throw new Error('invalid hash')
     }
     return this.serviceToInstance(hash, env)
   }
@@ -84,10 +84,9 @@ export default class ProcessCompile extends Command {
   async serviceToInstance(sidOrHash: string, env: string[]): Promise<hash> {
     const services = await this.lcd.service.list()
     if (!services) throw new Error('no services deployed, please deploy your service first')
-    const sidOrHashStr = sidOrHash.toString()
-    const match = services.filter(x => x.hash && x.hash === sidOrHashStr || x.sid && x.sid === sidOrHashStr)
-    if (!match || match.length === 0) throw new Error(`cannot find any service with the following: ${sidOrHashStr}`)
-    if (match.length > 1) throw new Error(`multiple services match the following sid: ${sidOrHashStr}, provide a service's hash instead`)
+    const match = services.filter(x => x.hash && x.hash === sidOrHash || x.sid && x.sid === sidOrHash)
+    if (!match || match.length === 0) throw new Error(`cannot find any service with the following: ${sidOrHash}`)
+    if (match.length > 1) throw new Error(`multiple services match the following sid: ${sidOrHash}, provide a service's hash instead`)
     const service = match[0]
     if (!service.hash) throw new Error('invalid service')
 

--- a/packages/cli/src/commands/process/detail.ts
+++ b/packages/cli/src/commands/process/detail.ts
@@ -1,5 +1,4 @@
-import {ProcessGetOutputs} from '@mesg/api/lib/process'
-import * as base58 from '@mesg/api/lib/util/base58'
+import {IProcess} from '@mesg/api/lib/process-lcd'
 
 import Command from '../../root-command'
 
@@ -15,9 +14,9 @@ export default class ProcessDetail extends Command {
     required: true
   }]
 
-  async run(): ProcessGetOutputs {
+  async run(): Promise<IProcess> {
     const {args} = this.parse(ProcessDetail)
-    const response = await this.api.process.get({hash: base58.decode(args.PROCESS_HASH)})
+    const response = await this.lcd.process.get(args.PROCESS_HASH)
     this.styledJSON(response)
     return response
   }

--- a/packages/cli/src/commands/process/list.ts
+++ b/packages/cli/src/commands/process/list.ts
@@ -1,6 +1,5 @@
 import cli from 'cli-ux'
-import {IProcess} from '@mesg/api/lib/process'
-import * as base58 from '@mesg/api/lib/util/base58'
+import {IProcess} from '@mesg/api/lib/process-lcd'
 
 import Command from '../../root-command'
 
@@ -14,11 +13,11 @@ export default class ProcessList extends Command {
 
   async run(): Promise<IProcess[]> {
     const {flags} = this.parse(ProcessList)
-    const {processes} = await this.api.process.list({})
-    cli.table(processes || [], {
-      hash: {header: 'HASH', get: x => x.hash ? base58.encode(x.hash) : ''},
-      name: {header: 'NAME', get: x => x.name},
+    const processes = await this.lcd.process.list()
+    cli.table(processes, {
+      hash: {header: 'HASH'},
+      name: {header: 'NAME'},
     }, {printLine: this.log, ...flags})
-    return processes || []
+    return processes
   }
 }

--- a/packages/cli/src/commands/service/detail.ts
+++ b/packages/cli/src/commands/service/detail.ts
@@ -1,4 +1,5 @@
-import {ServiceGetOutputs} from '@mesg/api/lib/service'
+import {IService} from '@mesg/api/lib/service-lcd'
+import {encode} from '@mesg/api/lib/util/base58'
 
 import Command from '../../root-command'
 import {serviceResolver} from '../../utils/resolver'
@@ -15,10 +16,10 @@ export default class ServiceDetail extends Command {
     required: true
   }]
 
-  async run(): ServiceGetOutputs {
+  async run(): Promise<IService> {
     const {args} = this.parse(ServiceDetail)
     const hash = await serviceResolver(this.api, args.SERVICE_HASH)
-    const response = await this.api.service.get({hash})
+    const response = await this.lcd.service.get(encode(hash))
     this.styledJSON(response)
     return response
   }

--- a/packages/cli/src/commands/service/dev.ts
+++ b/packages/cli/src/commands/service/dev.ts
@@ -53,7 +53,6 @@ export default class ServiceDev extends Command {
       dependencies: definition.dependencies,
       description: definition.description,
       events: definition.events,
-      hash: base58.encode(definition.hash),
       name: definition.name,
       repository: definition.repository,
       sid: definition.sid,

--- a/packages/cli/src/commands/service/dev.ts
+++ b/packages/cli/src/commands/service/dev.ts
@@ -48,7 +48,18 @@ export default class ServiceDev extends Command {
   }
 
   async createService(definition: IService): Promise<string> {
-    const hash = await this.lcd.service.hash(definition)
+    const hash = await this.lcd.service.hash({
+      configuration: definition.configuration,
+      dependencies: definition.dependencies,
+      description: definition.description,
+      events: definition.events,
+      hash: base58.encode(definition.hash),
+      name: definition.name,
+      repository: definition.repository,
+      sid: definition.sid,
+      source: definition.source,
+      tasks: definition.tasks
+    })
     if (!hash) throw new Error('invalid hash')
     const exists = await this.lcd.service.exists(hash)
     if (!exists) {

--- a/packages/cli/src/commands/service/dev.ts
+++ b/packages/cli/src/commands/service/dev.ts
@@ -65,7 +65,7 @@ export default class ServiceDev extends Command {
     if (!exists) {
       const service = await this.api.service.create(definition)
       if (!service.hash) throw new Error('invalid hash')
-      if (service.hash.toString() !== hash.toString()) throw new Error('invalid hash')
+      if (base58.encode(service.hash) !== hash) throw new Error('invalid hash')
     }
     return hash
   }

--- a/packages/cli/src/commands/service/execute.ts
+++ b/packages/cli/src/commands/service/execute.ts
@@ -36,7 +36,7 @@ export default class ServiceExecute extends Command {
   async run(): ExecutionCreateOutputs {
     const {args, flags} = this.parse(ServiceExecute)
 
-    const runnerHash = base58.encode(await runnerResolver(this.api, args.RUNNER_HASH))
+    const runnerHash = await runnerResolver(this.lcd, args.RUNNER_HASH)
 
     const runner = await this.lcd.runner.get(runnerHash)
     if (!runner.instanceHash) { throw new Error('invalid runner hash') }

--- a/packages/cli/src/commands/service/list.ts
+++ b/packages/cli/src/commands/service/list.ts
@@ -1,6 +1,5 @@
 import cli from 'cli-ux'
 import {IInstance} from '@mesg/api/lib/instance-lcd'
-import * as base58 from '@mesg/api/lib/util/base58'
 
 import Command from '../../root-command'
 
@@ -14,38 +13,38 @@ export default class ServiceList extends Command {
 
   async run(): Promise<IInstance[]> {
     const {flags} = this.parse(ServiceList)
-    const [services, instances, {runners}] = await Promise.all([
+    const [services, instances, runners] = await Promise.all([
       this.lcd.service.list(),
       this.lcd.instance.list(),
-      this.api.runner.list({}),
+      this.lcd.runner.list(),
     ])
     cli.table(services, {
       hash: {header: 'HASH', get: srv => srv.hash},
       sid: {header: 'SID', get: srv => srv.sid},
       instances: {
         header: 'INSTANCES',
-        get: srv => (instances || [])
+        get: srv => instances
           .filter(inst => inst.serviceHash === srv.hash)
           .map(inst => [
             inst.hash,
-            (runners || [])
-              .filter(run => base58.encode(run.instanceHash) === inst.hash)
+            runners
+              .filter(run => run.instanceHash === inst.hash)
               .reduce((p, _, i) => p + (i > 0 ? '\n' : ''), '')
           ].join(''))
         .join('\n'),
       },
       runners: {
         header: 'RUNNERS',
-        get: srv => (instances || [])
+        get: srv => instances
           .filter(inst => inst.serviceHash === srv.hash)
-          .map(inst => (runners || [])
-            .filter(run => base58.encode(run.instanceHash) === inst.hash)
-            .map(run => base58.encode(run.hash))
+          .map(inst => runners
+            .filter(run => run.instanceHash === inst.hash)
+            .map(run => run.hash)
             .join('\n'),
           )
           .join('\n'),
       }
     }, {printLine: this.log, ...flags})
-    return instances || []
+    return instances
   }
 }

--- a/packages/cli/src/commands/service/list.ts
+++ b/packages/cli/src/commands/service/list.ts
@@ -1,5 +1,5 @@
 import cli from 'cli-ux'
-import {IInstance} from '@mesg/api/lib/instance'
+import {IInstance} from '@mesg/api/lib/instance-lcd'
 import * as base58 from '@mesg/api/lib/util/base58'
 
 import Command from '../../root-command'
@@ -14,9 +14,9 @@ export default class ServiceList extends Command {
 
   async run(): Promise<IInstance[]> {
     const {flags} = this.parse(ServiceList)
-    const [services, {instances}, {runners}] = await Promise.all([
+    const [services, instances, {runners}] = await Promise.all([
       this.lcd.service.list(),
-      this.api.instance.list({}),
+      this.lcd.instance.list(),
       this.api.runner.list({}),
     ])
     cli.table(services, {
@@ -25,11 +25,11 @@ export default class ServiceList extends Command {
       instances: {
         header: 'INSTANCES',
         get: srv => (instances || [])
-          .filter(inst => base58.encode(inst.serviceHash) === srv.hash)
+          .filter(inst => inst.serviceHash === srv.hash)
           .map(inst => [
-            base58.encode(inst.hash),
+            inst.hash,
             (runners || [])
-              .filter(run => base58.encode(run.instanceHash) === base58.encode(inst.hash))
+              .filter(run => base58.encode(run.instanceHash) === inst.hash)
               .reduce((p, _, i) => p + (i > 0 ? '\n' : ''), '')
           ].join(''))
         .join('\n'),
@@ -37,9 +37,9 @@ export default class ServiceList extends Command {
       runners: {
         header: 'RUNNERS',
         get: srv => (instances || [])
-          .filter(inst => base58.encode(inst.serviceHash) === srv.hash)
+          .filter(inst => inst.serviceHash === srv.hash)
           .map(inst => (runners || [])
-            .filter(run => base58.encode(run.instanceHash) === base58.encode(inst.hash))
+            .filter(run => base58.encode(run.instanceHash) === inst.hash)
             .map(run => base58.encode(run.hash))
             .join('\n'),
           )

--- a/packages/cli/src/commands/service/logs.ts
+++ b/packages/cli/src/commands/service/logs.ts
@@ -63,7 +63,7 @@ export default class ServiceLogs extends Command {
   async run() {
     const {args, flags} = this.parse(ServiceLogs)
 
-    const runnerHash = base58.encode(await runnerResolver(this.api, args.RUNNER_HASH))
+    const runnerHash = await runnerResolver(this.lcd, args.RUNNER_HASH)
     const runner = await this.lcd.runner.get(runnerHash)
     if (!runner.hash) {
       throw new Error('runner is invalid')

--- a/packages/cli/src/commands/service/start.ts
+++ b/packages/cli/src/commands/service/start.ts
@@ -1,9 +1,10 @@
-import {flags} from '@oclif/command'
-import {RunnerCreateOutputs} from '@mesg/api/lib/runner'
+import { flags } from '@oclif/command'
+import { RunnerCreateOutputs } from '@mesg/api/lib/runner'
 import * as base58 from '@mesg/api/lib/util/base58'
 
 import Command from '../../root-command'
-import {serviceResolver} from '../../utils/resolver'
+import { serviceResolver } from '../../utils/resolver'
+import { IRunner } from '@mesg/api/lib/runner-lcd'
 
 export default class ServiceStart extends Command {
   static description = 'Start a service by creating a new runner'
@@ -22,18 +23,19 @@ export default class ServiceStart extends Command {
     required: true,
   }]
 
-  async run(): RunnerCreateOutputs {
-    const {args, flags} = this.parse(ServiceStart)
+  async run(): Promise<IRunner> {
+    const { args, flags } = this.parse(ServiceStart)
     this.spinner.start('Starting runner')
     const serviceHash = await serviceResolver(this.api, args.SERVICE_HASH)
-    const {hash} = await this.api.runner.create({
+    const response = await this.api.runner.create({
       serviceHash,
       env: flags.env
     })
-    if (!hash) throw new Error('invalid runner')
-    this.spinner.stop(base58.encode(hash))
-    const runner = await this.api.runner.get({hash})
-    this.log(`Runner started with hash ${base58.encode(hash)} and instance hash ${base58.encode(runner.instanceHash)}`)
-    return {hash}
+    if (!response.hash) throw new Error('invalid runner')
+    const hash = base58.encode(response.hash)
+    this.spinner.stop(hash)
+    const runner = await this.lcd.runner.get(hash)
+    this.log(`Runner started with hash ${hash} and instance hash ${runner.instanceHash}`)
+    return runner
   }
 }

--- a/packages/cli/src/commands/service/stop.ts
+++ b/packages/cli/src/commands/service/stop.ts
@@ -1,4 +1,5 @@
 import {flags} from '@oclif/command'
+import * as base58 from '@mesg/api/lib/util/base58'
 import cli from 'cli-ux'
 
 import Command from '../../root-command'
@@ -34,7 +35,7 @@ export default class ServiceStop extends Command {
     }
     this.spinner.start('Stop running services')
     for (const hash of argv) {
-      const runnerHash = await runnerResolver(this.api, hash)
+      const runnerHash = base58.decode(await runnerResolver(this.lcd, hash))
       await this.api.runner.delete({hash: runnerHash, deleteData: flags['delete-data']})
     }
     this.spinner.stop(argv.join(', '))

--- a/packages/cli/src/root-command.ts
+++ b/packages/cli/src/root-command.ts
@@ -3,6 +3,7 @@ import {IConfig} from '@oclif/config'
 import {cli} from 'cli-ux'
 import Application from '@mesg/application'
 import API from '@mesg/api'
+import LCD from '@mesg/api/lib/lcd'
 import {hash} from '@mesg/api/lib/types'
 import * as base58 from '@mesg/api/lib/util/base58'
 import {format, inspect} from 'util'
@@ -13,10 +14,12 @@ export default abstract class extends Command {
     quiet: flags.boolean({char: 'q', description: 'Display only essential information'}),
     silent: flags.boolean({hidden: true}),
     port: flags.integer({char: 'p', default: 50052, description: 'Port to access the MESG engine'}),
+    "lcd-port": flags.integer({default: 1317, description: 'Port to access the MESG engine LCD Api'}),
     host: flags.string({default: 'localhost', description: 'Host to access the MESG engine'})
   }
 
   public api: API
+  public lcd: LCD
   private readonly _app: Application
 
   constructor(argv: string[], config: IConfig) {
@@ -26,8 +29,8 @@ export default abstract class extends Command {
     const host = process.env.DOCKER_HOST
       ? new URL(process.env.DOCKER_HOST).hostname
       : flags.host
-    const endpoint = `${host}:${port}`
-    this.api = new API(endpoint)
+    this.api = new API(`${host}:${flags.port}`)
+    this.lcd = new LCD(`http://${host}:${flags['lcd-port']}`)
     this._app = new Application(this.api)
   }
 

--- a/packages/cli/src/utils/resolver.ts
+++ b/packages/cli/src/utils/resolver.ts
@@ -1,4 +1,5 @@
 import {hash, IApi} from '@mesg/api/lib/types'
+import LCD from '@mesg/api/lib/lcd'
 import * as base58 from '@mesg/api/lib/util/base58'
 import {resolveSID, resolveSIDRunner} from '@mesg/api/lib/util/resolve'
 
@@ -21,38 +22,20 @@ export const serviceResolver = async (api: IApi, sidOrHash: hash | string): Prom
   }
 }
 
-export const instanceResolver = async (api: IApi, sidOrHash: hash | string): Promise<hash> => {
+export const instanceResolver = async (api: LCD, sidOrHash: string): Promise<string> => {
   try {
-    let hash: hash
-    if (sidOrHash instanceof Uint8Array) {
-      hash = sidOrHash
-    } else {
-      hash = base58.decode(sidOrHash)
-    }
-    await api.instance.get({hash})
-    return hash
+    await api.instance.get(sidOrHash)
+    return sidOrHash
   } catch (err) {
-    if (typeof sidOrHash === 'string') {
-      return resolveSID(api, sidOrHash)
-    }
-    throw err
+    return resolveSID(api, sidOrHash)
   }
 }
 
-export const runnerResolver = async (api: IApi, sidOrHash: hash | string): Promise<hash> => {
+export const runnerResolver = async (api: LCD, sidOrHash: string): Promise<string> => {
   try {
-    let hash: hash
-    if (sidOrHash instanceof Uint8Array) {
-      hash = sidOrHash
-    } else {
-      hash = base58.decode(sidOrHash)
-    }
-    await api.runner.get({hash})
-    return hash
+    await api.runner.get(sidOrHash)
+    return sidOrHash
   } catch (err) {
-    if (typeof sidOrHash === 'string') {
-      return resolveSIDRunner(api, sidOrHash)
-    }
-    throw err
+    return resolveSIDRunner(api, sidOrHash)
   }
 }


### PR DESCRIPTION
The `@mesg/api` and `@mesg/cli` now interacts with the LCD server for all reading.
The writing will come on another PR.

Check-out the changelog for details.
- [`@mesg/api`](https://github.com/mesg-foundation/js-sdk/pull/179/files#diff-bf565e1b51033ca251748134ee50e506)
- [`@mesg/application`](https://github.com/mesg-foundation/js-sdk/pull/179/files#diff-758f2eb901bdc1e63edd83076d4fdecf)
- [`@mesg/cli`](https://github.com/mesg-foundation/js-sdk/pull/179/files#diff-005671596a68126a57cfcfd6f8b70402)