### PR TITLE
Smart stop of environment

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -39,6 +39,8 @@ Commands `service:dev` and `process:dev` are now smarter and automatically start
 
 #### Bug fixes
 
+- [#191](https://github.com/mesg-foundation/js-sdk/pull/191) Do not stop the environment if other instances of the CLI rely on it
+
 ## [v0.3.0](https://github.com/mesg-foundation/js-sdk/releases/tag/%40mesg%2Fcli%400.3.0)
 
 #### Improvements

--- a/packages/cli/src/commands/service/dev.ts
+++ b/packages/cli/src/commands/service/dev.ts
@@ -14,7 +14,7 @@ import version from '../../version'
 
 const ipfsClient = require('ipfs-http-client')
 
-type Context = Environment.IStop | Service.ICompile | Service.ICreate | Runner.ICreate | Runner.ILogs | Instance.IEventLogs | Runner.IResultLogs
+type Context = Environment.IStart | Service.ICompile | Service.ICreate | Runner.ICreate | Runner.ILogs | Instance.IEventLogs | Runner.IResultLogs
 type ContextEnd = Runner.ILogsStop | Instance.IEventLogsStop | Runner.IResultLogsStop | Environment.IStop
 
 export default class Dev extends Command {

--- a/packages/cli/src/tasks/environment.ts
+++ b/packages/cli/src/tasks/environment.ts
@@ -114,7 +114,7 @@ export const stop: ListrTask<IStop> = {
     },
     clearConfig,
     {
-      title: 'Unregister CLI',
+      title: 'Unregistering CLI',
       task: (ctx: IClearConfig) => removePID(ctx.configDir)
     },
   ])
@@ -126,7 +126,7 @@ export const start: ListrTask<IStart> = {
   task: () => new Listr<IStart>([
     createConfig,
     {
-      title: 'Register CLI',
+      title: 'Registering CLI',
       task: (ctx: ICreateConfig) => appendPID(ctx.configDir)
     },
     generateAccount,

--- a/packages/cli/src/tasks/environment.ts
+++ b/packages/cli/src/tasks/environment.ts
@@ -11,6 +11,25 @@ const loadYaml = (file: string) => existsSync(file)
   ? safeLoad(readFileSync(file).toString())
   : {}
 
+const pidFilename = 'pid.json'
+
+const pids = (path: string): number[] => existsSync(join(path, pidFilename))
+  ? JSON.parse(readFileSync(join(path, pidFilename)).toString()).map((x: any) => parseInt(x, 10))
+  : []
+
+const appendPID = (path: string) => {
+  const res = [...pids(path), process.pid].filter((value, index, self) => self.indexOf(value) === index)
+  writeFileSync(join(path, pidFilename), JSON.stringify(res))
+}
+
+const removePID = (path: string) => {
+  if (!existsSync(join(path, pidFilename))) return
+  const res = pids(path).filter(x => x !== process.pid)
+  writeFileSync(join(path, pidFilename), JSON.stringify(res))
+}
+
+const hasOtherInstances = (path: string) => pids(path).filter(x => x !== process.pid).length > 0
+
 export type ICreateConfig = { configDir: string }
 export const createConfig: ListrTask<ICreateConfig> = {
   title: 'Create default configuration',
@@ -21,6 +40,7 @@ export const createConfig: ListrTask<ICreateConfig> = {
 export type IClearConfig = { configDir: string }
 export const clearConfig: ListrTask<IClearConfig> = {
   title: 'Clear config',
+  skip: ctx => hasOtherInstances(ctx.configDir),
   task: ctx => (rmdirSync as any)(ctx.configDir, { recursive: true })
 }
 
@@ -69,12 +89,13 @@ export const lcdApiReady: ListrTask<ILCDApiReady> = {
   task: () => waitToBeReady()
 }
 
-export type IStop = {}
+export type IStop = { configDir: string }
 export const stop: ListrTask<IStop> = {
   title: 'Stop environment',
   task: () => new Listr<IStop | IClearConfig>([
     {
       title: 'Stop engine',
+      skip: (ctx) => hasOtherInstances(ctx.configDir),
       task: async () => {
         const services = await listServices({ name: ['engine'] })
         if (services.length === 0) throw new Error('Cannot find engine')
@@ -91,7 +112,11 @@ export const stop: ListrTask<IStop> = {
         await eventPromise
       }
     },
-    clearConfig
+    clearConfig,
+    {
+      title: 'Unregister CLI',
+      task: (ctx: IClearConfig) => removePID(ctx.configDir)
+    },
   ])
 }
 
@@ -100,6 +125,10 @@ export const start: ListrTask<IStart> = {
   title: 'Start environment',
   task: () => new Listr<IStart>([
     createConfig,
+    {
+      title: 'Register CLI',
+      task: (ctx: ICreateConfig) => appendPID(ctx.configDir)
+    },
     generateAccount,
     updateDockerImage,
     startEngine,


### PR DESCRIPTION
Dependency: https://github.com/mesg-foundation/js-sdk/pull/188

Right now it is possible to start multiple services/processes but as long as one is stopped, the whole environment will stop as well.
This pull request add the support of "smart" stop of the environment. Only the last cli to shut down will stop the environment, the others will just bypass the step if there are still instances running an environment.