### PR TITLE
Change path for local blockchain state

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -39,6 +39,7 @@ Commands `service:dev` and `process:dev` are automatically start a local environ
 - [#193](https://github.com/mesg-foundation/js-sdk/pull/193) Add login/logout commands with synchronization in the user's configs
 - [#194](https://github.com/mesg-foundation/js-sdk/pull/194) Add `deploy:service` command
 - [#196](https://github.com/mesg-foundation/js-sdk/pull/196) Update code organization for tasks
+- [#](https://github.com/mesg-foundation/js-sdk/pull/) State of the local chain in the `dataDir` (https://oclif.io/docs/config)
 
 #### Bug fixes
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -39,7 +39,7 @@ Commands `service:dev` and `process:dev` are automatically start a local environ
 - [#193](https://github.com/mesg-foundation/js-sdk/pull/193) Add login/logout commands with synchronization in the user's configs
 - [#194](https://github.com/mesg-foundation/js-sdk/pull/194) Add `deploy:service` command
 - [#196](https://github.com/mesg-foundation/js-sdk/pull/196) Update code organization for tasks
-- [#](https://github.com/mesg-foundation/js-sdk/pull/) State of the local chain in the `dataDir` (https://oclif.io/docs/config)
+- [#197](https://github.com/mesg-foundation/js-sdk/pull/197) State of the local chain in the `dataDir` (https://oclif.io/docs/config)
 
 #### Bug fixes
 

--- a/packages/cli/src/commands/process/dev.ts
+++ b/packages/cli/src/commands/process/dev.ts
@@ -24,8 +24,6 @@ export default class Dev extends Command {
     image: flags.string({ name: 'Engine image', default: 'mesg/engine' }),
     tag: flags.string({ name: 'Engine version', default: version.engine }),
     pull: flags.boolean({ name: 'Force to pull the docker image', default: false }),
-    configDir: flags.string({ name: 'Configuration directory', default: join(process.cwd(), '.mesg') }),
-    configFile: flags.string({ name: 'Config filename', default: 'config.yml' }),
     env: flags.string({
       description: 'Environment variables to inject to the process',
       multiple: true,
@@ -80,8 +78,7 @@ export default class Dev extends Command {
       }
     ])
     await tasks.run({
-      configDir: flags.configDir,
-      configFile: flags.configFile,
+      configDir: this.config.dataDir,
       image: flags.image,
       pull: flags.pull,
       tag: flags.tag,
@@ -115,7 +112,7 @@ export default class Dev extends Command {
         },
         Environment.stop
       ]).run({
-        configDir: flags.configFile
+        configDir: this.config.dataDir
       })
     })
   }

--- a/packages/cli/src/commands/service/dev.ts
+++ b/packages/cli/src/commands/service/dev.ts
@@ -28,8 +28,6 @@ export default class Dev extends Command {
     image: flags.string({ name: 'Engine image', default: 'mesg/engine' }),
     tag: flags.string({ name: 'Engine version', default: version.engine }),
     pull: flags.boolean({ name: 'Force to pull the docker image', default: false }),
-    configDir: flags.string({ name: 'Configuration directory', default: join(process.cwd(), '.mesg') }),
-    configFile: flags.string({ name: 'Config filename', default: 'config.yml' }),
     env: flags.string({
       description: 'Environment variables to inject to the service',
       multiple: true,
@@ -122,8 +120,7 @@ export default class Dev extends Command {
       }
     ])
     await tasks.run({
-      configDir: flags.configDir,
-      configFile: flags.configFile,
+      configDir: this.config.dataDir,
       image: flags.image,
       pull: flags.pull,
       tag: flags.tag,
@@ -159,7 +156,7 @@ export default class Dev extends Command {
         },
         Environment.stop,
       ]).run({
-        configDir: flags.configFile
+        configDir: this.config.dataDir
       })
     })
   }

--- a/packages/cli/src/utils/config.ts
+++ b/packages/cli/src/utils/config.ts
@@ -4,23 +4,25 @@ import { join } from "path"
 import Account from "@mesg/api/lib/account-lcd"
 import merge from "lodash.merge"
 
-export const clear = (dir: string): void => {
-  (rmdirSync as any)(dir, { recursive: true })
+const FILE = 'config.yml'
+
+export const clear = (path: string): void => {
+  (rmdirSync as any)(path, { recursive: true })
 }
 
 export const read = (path: string): any => {
-  return existsSync(path)
-    ? safeLoad(readFileSync(path).toString())
+  return existsSync(join(path, FILE))
+    ? safeLoad(readFileSync(join(path, FILE)).toString())
     : {}
 }
 
 export const write = (path: string, config: any) => {
   const newConfigs = merge({}, read(path), config)
-  writeFileSync(path, safeDump(newConfigs))
+  writeFileSync(join(path, FILE), safeDump(newConfigs))
 }
 
-export const getOrGenerateAccount = (configDir: string, configFile: string): string => {
-  const configAccount = read(join(configDir, configFile)).account || {}
+export const getOrGenerateAccount = (path: string): string => {
+  const configAccount = read(path).account || {}
   return configAccount.mnemonic
     ? configAccount.mnemonic
     : Account.generateMnemonic()

--- a/packages/cli/src/utils/environment-tasks.ts
+++ b/packages/cli/src/utils/environment-tasks.ts
@@ -93,7 +93,7 @@ export const start: ListrTask<IStart> = {
     {
       title: 'Generating test account',
       skip: ctx => ctx.mnemonic,
-      task: ctx => ctx.mnemonic = getOrGenerateAccount(ctx.configDir, ctx.configFile)
+      task: ctx => ctx.mnemonic = getOrGenerateAccount(ctx.configDir)
     },
     {
       title: 'Updating the Engine image',
@@ -104,7 +104,7 @@ export const start: ListrTask<IStart> = {
       title: 'Starting the Engine',
       skip: async () => (await listServices({ name: ['engine'] })).length > 0,
       task: ctx => {
-        write(join(ctx.configDir, ctx.configFile), {
+        write(ctx.configDir, {
           account: {
             mnemonic: ctx.mnemonic
           }

--- a/packages/cli/src/utils/environment-tasks.ts
+++ b/packages/cli/src/utils/environment-tasks.ts
@@ -84,7 +84,7 @@ export const start: ListrTask<IStart> = {
     {
       title: 'Creating default configuration',
       skip: ctx => existsSync(ctx.configDir),
-      task: ctx => mkdirSync(ctx.configDir)
+      task: ctx => mkdirSync(ctx.configDir, { recursive: true })
     },
     {
       title: 'Registering CLI',

--- a/packages/cli/src/utils/environment-tasks.ts
+++ b/packages/cli/src/utils/environment-tasks.ts
@@ -77,7 +77,7 @@ export const stop: ListrTask<IStop> = {
   ])
 }
 
-export type IStart = { configDir: string, configFile: string, pull: boolean, image: string, tag: string, endpoint: string, mnemonic?: string }
+export type IStart = { configDir: string, pull: boolean, image: string, tag: string, endpoint: string, mnemonic?: string }
 export const start: ListrTask<IStart> = {
   title: 'Start environment',
   task: () => new Listr([


### PR DESCRIPTION
dependency: https://github.com/mesg-foundation/js-sdk/pull/196

The local state (`.mesg` directory) is now located in the dataDir of the user and not the current path.

https://oclif.io/docs/config
> dataDir - CLI data directory
    Unix: ~/.data/mycli
  Windows: %LOCALAPPDATA%\mycli
  Can be overridden with XDG_DATA_HOME


I also removed the flag in order to simplify the cli and the `configFile` was not read anyway by the engine.
