### PR TITLE
Add any value for filter condition + support of reference for the compilation

### DIFF
--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [#188](https://github.com/mesg-foundation/js-sdk/pull/188) Add mnemonic generation to account
 - [#199](https://github.com/mesg-foundation/js-sdk/pull/199) Add helper to get a hash of a resource created from a tx result
 - [#199](https://github.com/mesg-foundation/js-sdk/pull/199) Add create/delete/hash messages for runners
+- [#203](https://github.com/mesg-foundation/js-sdk/pull/203) Update LCD types and add process filters value and reference
 
 #### Bug fixes
 

--- a/packages/api/src/execution-lcd.ts
+++ b/packages/api/src/execution-lcd.ts
@@ -22,6 +22,13 @@ export type IExecution = {
   processHash?: (string | null);
   nodeKey?: (string | null);
   executorHash: string;
+  price?: string;
+  blockHeight?: number;
+  emitters?: {
+    runnerHash: string;
+    blockHeight: number;
+  }[];
+  address?: string
 }
 
 export default class Execution extends LCDClient {

--- a/packages/api/src/mock.ts
+++ b/packages/api/src/mock.ts
@@ -41,7 +41,7 @@ export default (endpoint: string): IApi => ({
   },
   runner: {
     async create() { return { hash } },
-    async get() { return { hash: hash, address: '', instanceHash: hash } },
+    async get() { return { hash: hash, owner: '', instanceHash: hash } },
     async list() { return { runners: [] } },
     async delete() { return {} }
   },

--- a/packages/api/src/ownership-lcd.ts
+++ b/packages/api/src/ownership-lcd.ts
@@ -12,6 +12,7 @@ export type IOwnership = {
   owner: string;
   resourceHash: string;
   resource: Resource;
+  resourceAddress: string;
 }
 
 export default class Ownership extends LCDClient {

--- a/packages/api/src/process-lcd.ts
+++ b/packages/api/src/process-lcd.ts
@@ -109,10 +109,44 @@ export enum FilterPredicate {
   CONTAINS = 6
 }
 
+export type IFilterValueNullType = {
+  type: 'mesg.types.Value_NullValue';
+  value: {
+    null?: 0
+  }
+}
+
+export type IFilterValueStringType = {
+  type: 'mesg.types.Value_StringValue';
+  value: {
+    string_value: string;
+  }
+}
+
+export type IFilterValueDoubleType = {
+  type: 'mesg.types.Value_DoubleValue';
+  value: {
+    double_value: number;
+  }
+}
+
+export type IFilterValueBoolType = {
+  type: 'mesg.types.Value_BoolValue';
+  value: {
+    bool_value: boolean;
+  }
+}
+
+
 export type IFilterCondition = {
-  ref: IReference;
+  ref: {
+    nodeKey: string;
+    path: IRefPath;
+  };
   predicate: FilterPredicate;
-  value: ProcessType.mesg.protobuf.IValue;
+  value: {
+    Kind: IFilterValueNullType | IFilterValueStringType | IFilterValueDoubleType | IFilterValueBoolType
+  };
 }
 
 export type IFilter = {

--- a/packages/api/src/process-lcd.ts
+++ b/packages/api/src/process-lcd.ts
@@ -62,14 +62,14 @@ export type IOutputMapType = {
 }
 
 export type IRefSelectorKey = {
-  type: "mesg.types.Process_Node_Map_Output_Reference_Path_Key";
+  type: "mesg.types.Process_Node_Reference_Path_Key";
   value: {
     key: string;
   }
 }
 
 export type IRefSelectorIndex = {
-  type: "mesg.types.Process_Node_Map_Output_Reference_Path_Index";
+  type: "mesg.types.Process_Node_Reference_Path_Index";
   value: {
     index?: string;
   }
@@ -80,8 +80,8 @@ export type IRefPath = {
   Selector: IRefSelectorKey | IRefSelectorIndex
 }
 
-export type IOutputRefType = {
-  type: 'mesg.types.Process_Node_Map_Output_Ref';
+export type IReference = {
+  type: 'mesg.types.Process_Node_Reference';
   value: {
     ref: {
       nodeKey: string;
@@ -91,7 +91,7 @@ export type IOutputRefType = {
 }
 
 export type IOutput = {
-  Value: IOutputNullType | IOutputStringType | IOutputDoubleType | IOutputBoolType | IOutputListType | IOutputMapType | IOutputRefType
+  Value: IOutputNullType | IOutputStringType | IOutputDoubleType | IOutputBoolType | IOutputListType | IOutputMapType | IReference
 }
 
 export type IMapOutput = {
@@ -101,13 +101,18 @@ export type IMapOutput = {
 
 export enum FilterPredicate {
   Unknown = 0,
-  EQ = 1
+  EQ = 1,
+  GT = 2,
+  GTE = 3,
+  LT = 4,
+  LTE = 5,
+  CONTAINS = 6
 }
 
 export type IFilterCondition = {
-  key: string;
+  ref: IReference;
   predicate: FilterPredicate;
-  value: string;
+  value: ProcessType.mesg.protobuf.IValue;
 }
 
 export type IFilter = {

--- a/packages/api/src/process-lcd.ts
+++ b/packages/api/src/process-lcd.ts
@@ -123,10 +123,10 @@ export type IFilterValueStringType = {
   }
 }
 
-export type IFilterValueDoubleType = {
-  type: 'mesg.types.Value_DoubleValue';
+export type IFilterValueNumberType = {
+  type: 'mesg.types.Value_NumberValue';
   value: {
-    double_value: number;
+    number_value: number;
   }
 }
 
@@ -145,7 +145,7 @@ export type IFilterCondition = {
   };
   predicate: FilterPredicate;
   value: {
-    Kind: IFilterValueNullType | IFilterValueStringType | IFilterValueDoubleType | IFilterValueBoolType
+    Kind: IFilterValueNullType | IFilterValueStringType | IFilterValueNumberType | IFilterValueBoolType
   };
 }
 

--- a/packages/api/src/protobuf/api/execution.proto
+++ b/packages/api/src/protobuf/api/execution.proto
@@ -70,6 +70,11 @@ message CreateExecutionRequest {
     (gogoproto.customtype) = "github.com/mesg-foundation/engine/hash.Hash",
     (gogoproto.nullable) = false
   ];
+
+  // price of running the execution.
+  string price = 10 [
+    (gogoproto.moretags) = 'validate:"coins"'
+  ];
 }
 
 // CreateExecutionResponse defines response for execution creation.
@@ -155,5 +160,7 @@ message ListExecutionRequest {}
 // The response's data for the `List` API.
 message ListExecutionResponse {
   // List of executions that match the request's filters.
-  repeated types.Execution executions = 1;
+  repeated types.Execution executions = 1 [
+    (gogoproto.moretags) = 'validate:"dive"'
+  ];
 }

--- a/packages/api/src/protobuf/api/instance.proto
+++ b/packages/api/src/protobuf/api/instance.proto
@@ -48,5 +48,7 @@ message ListInstanceRequest {
 // The response's data for the `List` API.
 message ListInstanceResponse {
   // List of instances that match the request's filters.
-  repeated types.Instance instances = 1;
+  repeated types.Instance instances = 1 [
+    (gogoproto.moretags) = 'validate:"dive"'
+  ];
 }

--- a/packages/api/src/protobuf/api/ownership.proto
+++ b/packages/api/src/protobuf/api/ownership.proto
@@ -23,5 +23,7 @@ message ListOwnershipRequest {}
 // The response's data for the `List` API.
 message ListOwnershipResponse {
   // List of ownerships that match the request's filters.
-  repeated types.Ownership ownerships = 1;
+  repeated types.Ownership ownerships = 1 [
+    (gogoproto.moretags) = 'validate:"dive"'
+  ];
 }

--- a/packages/api/src/protobuf/api/process.proto
+++ b/packages/api/src/protobuf/api/process.proto
@@ -36,10 +36,14 @@ message CreateProcessRequest {
   ];
 
   // List of nodes of the process.
-  repeated types.Process.Node nodes = 4;
+  repeated types.Process.Node nodes = 4 [
+    (gogoproto.moretags) = 'validate:"dive"'
+  ];
 
   // List of edges of the process.
-  repeated types.Process.Edge edges = 5;
+  repeated types.Process.Edge edges = 5 [
+    (gogoproto.moretags) = 'validate:"dive"'
+  ];
 }
 
 // The response's data for the `Create` API.
@@ -80,5 +84,7 @@ message ListProcessRequest {}
 // The response's data for the `List` API.
 message ListProcessResponse {
   // List of processes that match the request's filters.
-  repeated types.Process processes = 1;
+  repeated types.Process processes = 1 [
+    (gogoproto.moretags) = 'validate:"dive"'
+  ];
 }

--- a/packages/api/src/protobuf/api/runner.proto
+++ b/packages/api/src/protobuf/api/runner.proto
@@ -47,8 +47,8 @@ message ListRunnerRequest {
       (gogoproto.nullable) = false
     ];
 
-    // Filter by address
-    string address = 2 [
+    // Filter by owner
+    string owner = 2 [
       (gogoproto.moretags) = 'validate:"accaddress"'
     ];
   }
@@ -60,7 +60,9 @@ message ListRunnerRequest {
 // The response's data for the `List` API.
 message ListRunnerResponse {
   // List of runners that match the request's filters.
-  repeated types.Runner runners = 1;
+  repeated types.Runner runners = 1 [
+    (gogoproto.moretags) = 'validate:"dive"'
+  ];
 }
 
 // The request's data for the `Create` API.

--- a/packages/api/src/protobuf/api/service.proto
+++ b/packages/api/src/protobuf/api/service.proto
@@ -104,7 +104,9 @@ message ListServiceRequest {}
 // The response's data for the `List` API.
 message ListServiceResponse {
   // List of services that match the request's filters.
-  repeated types.Service services = 1;
+  repeated types.Service services = 1 [
+    (gogoproto.moretags) = 'validate:"dive"'
+  ];
 }
 
 // The request's data for the `List` API.

--- a/packages/api/src/protobuf/types/execution.proto
+++ b/packages/api/src/protobuf/types/execution.proto
@@ -16,16 +16,17 @@ enum Status {
   // Unknown status represents any status unknown to execution.
   Unknown = 0;
 
-  // Created is an initial status after execution creation.
-  Created = 1;
+  // Proposed is the initial status of an execution.
+  // More emitters must submit the same execution to reach consensus.
+  Proposed = 1;
 
-  // InProgress informs that processing of execution has been started.
+  // InProgress informs that the execution reach consensus and the processing of execution must start.
   InProgress = 2;
 
-  // Completed is a success status after execution was processed.
+  // Completed is a success status after execution was processed and result submitted.
   Completed = 3;
 
-  // Failed is an error status after execution was processed.
+  // Failed is an error status after execution was processed but an error occured.
   Failed = 4;
 }
 
@@ -108,5 +109,41 @@ message Execution {
     (gogoproto.moretags) = 'hash:"name:13"',
     (gogoproto.customtype) = "github.com/mesg-foundation/engine/hash.Hash",
     (gogoproto.nullable) = false
+  ];
+
+  // price of running the exeuction.
+  string price = 14 [
+    (gogoproto.moretags) = 'hash:"name:14" validate:"coins"'
+  ];
+
+  // blockHeight where the execution was included into blockchain.
+  int64 blockHeight = 15 [
+    (gogoproto.moretags) = 'hash:"-"'
+  ];
+
+  // Emitter is a runner that proposed an execution.
+  message Emitter {
+    // Emitter's hash.
+    bytes runnerHash = 1 [
+      (gogoproto.moretags) = 'hash:"-" validate:"hash"',
+      (gogoproto.customtype) = "github.com/mesg-foundation/engine/hash.Hash",
+      (gogoproto.nullable) = false
+    ];
+
+    // Block height when this emitter proposed the execution.
+    int64 blockHeight = 2 [
+      (gogoproto.moretags) = 'hash:"-"'
+    ];
+  }
+    
+  // list of emitters of this execution.
+  repeated Emitter emitters = 16 [
+    (gogoproto.moretags) = 'hash:"-" validate:"dive"'
+  ];
+
+  // The address of the execution.
+  bytes address = 17 [
+    (gogoproto.moretags) = 'hash:"-" validate:"accaddress"',
+    (gogoproto.casttype) = "github.com/cosmos/cosmos-sdk/types.AccAddress"
   ];
 }

--- a/packages/api/src/protobuf/types/ownership.proto
+++ b/packages/api/src/protobuf/types/ownership.proto
@@ -35,8 +35,15 @@ message Ownership {
     None = 0;
     Service = 1;
     Process = 2;
+    Runner = 3;
   }
 
   // Resource's type.
   Resource resource = 4;
+
+  // The address of the resource.
+  bytes resourceAddress = 5 [
+    (gogoproto.moretags) = 'hash:"-" validate:"accaddress"',
+    (gogoproto.casttype) = "github.com/cosmos/cosmos-sdk/types.AccAddress"
+  ];
 }

--- a/packages/api/src/protobuf/types/process.proto
+++ b/packages/api/src/protobuf/types/process.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 
 import "gogo/protobuf/gogoproto/gogo.proto";
+import "protobuf/types/struct.proto";
 
 package mesg.types;
 option go_package = "github.com/mesg-foundation/engine/process";
@@ -74,32 +75,6 @@ message Process {
           ];
         }
 
-        message Reference {
-          message Path {
-            oneof selector {
-              string key = 1 [
-                (gogoproto.moretags) = 'hash:"name:1" validate:"printascii"'
-              ];
-              uint64 index = 2 [
-                (gogoproto.moretags) = 'hash:"name:2"'
-              ];
-            }
-
-            // Path can be nil if on the leaf
-            Path path = 3 [
-              (gogoproto.moretags) = 'hash:"name:3"'
-            ];
-          }
-
-          string nodeKey = 1 [
-            (gogoproto.moretags) = 'hash:"name:1" validate:"required"'
-          ];
-
-          Path path = 2 [
-            (gogoproto.moretags) = 'hash:"name:2"'
-          ];
-        }
-
         oneof value {
           Null null = 1 [
             (gogoproto.moretags) = 'hash:"name:1"'
@@ -149,12 +124,22 @@ message Process {
 
           // Equal
           EQ = 1;
-        }
 
-        // Key to check.
-        string key = 1 [
-          (gogoproto.moretags) = 'hash:"name:1" validate:"required,printascii"'
-        ];
+          // Greater than
+          GT = 2;
+
+          // Greater or equal than
+          GTE = 3;
+
+          // Lesser than
+          LT = 4;
+
+          // Lesser or equal than
+          LTE = 5;
+
+          // CONTAINS
+          CONTAINS = 6;
+        }
 
         // Type of condition to apply.
         Predicate predicate = 2 [
@@ -162,15 +147,47 @@ message Process {
         ];
 
         // Value of the filter.
-        string value = 3 [
-          (gogoproto.moretags) = 'hash:"name:3"'
+        mesg.protobuf.Value value = 4 [
+          (gogoproto.moretags) = 'hash:"name:4" validate:"required"'
+        ];
+
+        // Input defined as reference.
+        Reference ref = 5 [
+          (gogoproto.moretags) = 'hash:"name:5" validate:"required"'
         ];
       }
 
       // List of condition to apply for this filter
       repeated Condition conditions = 2 [
-        (gogoproto.moretags) = 'hash:"name:2"',
+        (gogoproto.moretags) = 'hash:"name:2" validate:"dive"',
         (gogoproto.nullable) = false
+      ];
+    }
+
+    message Reference {
+      message Path {
+        oneof selector {
+          string key = 1 [
+            (gogoproto.moretags) = 'hash:"name:1" validate:"printascii"'
+          ];
+          uint64 index = 2 [
+            (gogoproto.moretags) = 'hash:"name:2"'
+          ];
+        }
+
+        // Path can be nil if on the leaf
+        Path path = 3 [
+          (gogoproto.moretags) = 'hash:"name:3"'
+        ];
+      }
+
+      string nodeKey = 1 [
+        (gogoproto.moretags) = 'hash:"name:1" validate:"required"'
+      ];
+
+      // Path can be nil if referencing the whole node's output
+      Path path = 2 [
+        (gogoproto.moretags) = 'hash:"name:2"'
       ];
     }
 
@@ -235,5 +252,11 @@ message Process {
   // Edges to create the link between the nodes.
   repeated Edge edges = 5 [
     (gogoproto.moretags) = 'hash:"name:5" validate:"dive,required"'
+  ];
+
+  // The address of the process.
+  bytes address = 6 [
+    (gogoproto.moretags) = 'hash:"-"',
+    (gogoproto.casttype) = "github.com/cosmos/cosmos-sdk/types.AccAddress"
   ];
 }

--- a/packages/api/src/protobuf/types/runner.proto
+++ b/packages/api/src/protobuf/types/runner.proto
@@ -17,8 +17,8 @@ message Runner {
     (gogoproto.nullable) = false
   ];
 
-  // address of the engine of this runner
-  string address = 2 [
+  // owner of the engine of this runner
+  string owner = 2 [
     (gogoproto.moretags) = 'hash:"name:2"'
   ];
 
@@ -27,5 +27,11 @@ message Runner {
     (gogoproto.moretags) = 'hash:"name:3"',
     (gogoproto.customtype) = "github.com/mesg-foundation/engine/hash.Hash",
     (gogoproto.nullable) = false
+  ];
+
+  // The address of the runner.
+  bytes address = 4 [
+    (gogoproto.moretags) = 'hash:"-" validate:"accaddress"',
+    (gogoproto.casttype) = "github.com/cosmos/cosmos-sdk/types.AccAddress"
   ];
 }

--- a/packages/api/src/protobuf/types/service.proto
+++ b/packages/api/src/protobuf/types/service.proto
@@ -229,4 +229,10 @@ message Service {
   string source = 13 [
     (gogoproto.moretags) = 'hash:"name:13" validate:"required,printascii"'
   ];
+
+  // The address of the service.
+  bytes address = 14 [
+    (gogoproto.moretags) = 'hash:"-" validate:"accaddress"',
+    (gogoproto.casttype) = "github.com/cosmos/cosmos-sdk/types.AccAddress"
+  ];
 }

--- a/packages/api/src/runner-lcd.ts
+++ b/packages/api/src/runner-lcd.ts
@@ -3,8 +3,9 @@ import { IMsg } from './transaction'
 
 export type IRunner = {
   hash: string;
-  address: string;
-  instanceHash?: string | null;
+  owner: string;
+  instanceHash: string | null;
+  address: string | null;
 }
 
 export type IMsgCreate = {

--- a/packages/api/src/service-lcd.ts
+++ b/packages/api/src/service-lcd.ts
@@ -13,6 +13,7 @@ export type IService = {
   dependencies?: ServiceType.mesg.types.Service.IDependency[] | null;
   repository?: string | null;
   source?: string | null;
+  address?: string | null;
 }
 
 export type IMsgCreate = {

--- a/packages/api/src/typedef/execution.d.ts
+++ b/packages/api/src/typedef/execution.d.ts
@@ -13,7 +13,7 @@ declare namespace mesg {
             /** Status enum. */
             enum Status {
                 Unknown = 0,
-                Created = 1,
+                Proposed = 1,
                 InProgress = 2,
                 Completed = 3,
                 Failed = 4
@@ -60,6 +60,18 @@ declare namespace mesg {
 
                 /** Execution executorHash */
                 executorHash?: (Uint8Array|null);
+
+                /** Execution price */
+                price?: (string|null);
+
+                /** Execution blockHeight */
+                blockHeight?: (number|Long|null);
+
+                /** Execution emitters */
+                emitters?: (mesg.types.Execution.IEmitter[]|null);
+
+                /** Execution address */
+                address?: (Uint8Array|null);
             }
 
             /** Represents an Execution. */
@@ -109,6 +121,47 @@ declare namespace mesg {
 
                 /** Execution executorHash. */
                 public executorHash: Uint8Array;
+
+                /** Execution price. */
+                public price: string;
+
+                /** Execution blockHeight. */
+                public blockHeight: (number|Long);
+
+                /** Execution emitters. */
+                public emitters: mesg.types.Execution.IEmitter[];
+
+                /** Execution address. */
+                public address: Uint8Array;
+            }
+
+            namespace Execution {
+
+                /** Properties of an Emitter. */
+                interface IEmitter {
+
+                    /** Emitter runnerHash */
+                    runnerHash?: (Uint8Array|null);
+
+                    /** Emitter blockHeight */
+                    blockHeight?: (number|Long|null);
+                }
+
+                /** Represents an Emitter. */
+                class Emitter implements IEmitter {
+
+                    /**
+                     * Constructs a new Emitter.
+                     * @param [properties] Properties to set
+                     */
+                    constructor(properties?: mesg.types.Execution.IEmitter);
+
+                    /** Emitter runnerHash. */
+                    public runnerHash: Uint8Array;
+
+                    /** Emitter blockHeight. */
+                    public blockHeight: (number|Long);
+                }
             }
         }
 
@@ -363,6 +416,9 @@ declare namespace mesg {
 
                 /** CreateExecutionRequest executorHash */
                 executorHash?: (Uint8Array|null);
+
+                /** CreateExecutionRequest price */
+                price?: (string|null);
             }
 
             /** Represents a CreateExecutionRequest. */
@@ -397,6 +453,9 @@ declare namespace mesg {
 
                 /** CreateExecutionRequest executorHash. */
                 public executorHash: Uint8Array;
+
+                /** CreateExecutionRequest price. */
+                public price: string;
             }
 
             /** Properties of a CreateExecutionResponse. */

--- a/packages/api/src/typedef/ownership.d.ts
+++ b/packages/api/src/typedef/ownership.d.ts
@@ -24,6 +24,9 @@ declare namespace mesg {
 
                 /** Ownership resource */
                 resource?: (mesg.types.Ownership.Resource|null);
+
+                /** Ownership resourceAddress */
+                resourceAddress?: (Uint8Array|null);
             }
 
             /** Represents an Ownership. */
@@ -46,6 +49,9 @@ declare namespace mesg {
 
                 /** Ownership resource. */
                 public resource: mesg.types.Ownership.Resource;
+
+                /** Ownership resourceAddress. */
+                public resourceAddress: Uint8Array;
             }
 
             namespace Ownership {
@@ -54,7 +60,8 @@ declare namespace mesg {
                 enum Resource {
                     None = 0,
                     Service = 1,
-                    Process = 2
+                    Process = 2,
+                    Runner = 3
                 }
             }
         }

--- a/packages/api/src/typedef/process.d.ts
+++ b/packages/api/src/typedef/process.d.ts
@@ -24,6 +24,9 @@ declare namespace mesg {
 
                 /** Process edges */
                 edges?: (mesg.types.Process.IEdge[]|null);
+
+                /** Process address */
+                address?: (Uint8Array|null);
             }
 
             /** Represents a Process. */
@@ -46,6 +49,9 @@ declare namespace mesg {
 
                 /** Process edges. */
                 public edges: mesg.types.Process.IEdge[];
+
+                /** Process address. */
+                public address: Uint8Array;
             }
 
             namespace Process {
@@ -221,7 +227,7 @@ declare namespace mesg {
                             boolConst?: (boolean|null);
 
                             /** Output ref */
-                            ref?: (mesg.types.Process.Node.Map.Output.IReference|null);
+                            ref?: (mesg.types.Process.Node.IReference|null);
 
                             /** Output list */
                             list?: (mesg.types.Process.Node.Map.Output.IList|null);
@@ -252,7 +258,7 @@ declare namespace mesg {
                             public boolConst: boolean;
 
                             /** Output ref. */
-                            public ref?: (mesg.types.Process.Node.Map.Output.IReference|null);
+                            public ref?: (mesg.types.Process.Node.IReference|null);
 
                             /** Output list. */
                             public list?: (mesg.types.Process.Node.Map.Output.IList|null);
@@ -310,70 +316,6 @@ declare namespace mesg {
                                 /** Map outputs. */
                                 public outputs: { [k: string]: mesg.types.Process.Node.Map.IOutput };
                             }
-
-                            /** Properties of a Reference. */
-                            interface IReference {
-
-                                /** Reference nodeKey */
-                                nodeKey?: (string|null);
-
-                                /** Reference path */
-                                path?: (mesg.types.Process.Node.Map.Output.Reference.IPath|null);
-                            }
-
-                            /** Represents a Reference. */
-                            class Reference implements IReference {
-
-                                /**
-                                 * Constructs a new Reference.
-                                 * @param [properties] Properties to set
-                                 */
-                                constructor(properties?: mesg.types.Process.Node.Map.Output.IReference);
-
-                                /** Reference nodeKey. */
-                                public nodeKey: string;
-
-                                /** Reference path. */
-                                public path?: (mesg.types.Process.Node.Map.Output.Reference.IPath|null);
-                            }
-
-                            namespace Reference {
-
-                                /** Properties of a Path. */
-                                interface IPath {
-
-                                    /** Path key */
-                                    key?: (string|null);
-
-                                    /** Path index */
-                                    index?: (number|Long|null);
-
-                                    /** Path path */
-                                    path?: (mesg.types.Process.Node.Map.Output.Reference.IPath|null);
-                                }
-
-                                /** Represents a Path. */
-                                class Path implements IPath {
-
-                                    /**
-                                     * Constructs a new Path.
-                                     * @param [properties] Properties to set
-                                     */
-                                    constructor(properties?: mesg.types.Process.Node.Map.Output.Reference.IPath);
-
-                                    /** Path key. */
-                                    public key: string;
-
-                                    /** Path index. */
-                                    public index: (number|Long);
-
-                                    /** Path path. */
-                                    public path?: (mesg.types.Process.Node.Map.Output.Reference.IPath|null);
-
-                                    /** Path selector. */
-                                    public selector?: ("key"|"index");
-                                }
-                            }
                         }
                     }
 
@@ -402,14 +344,14 @@ declare namespace mesg {
                         /** Properties of a Condition. */
                         interface ICondition {
 
-                            /** Condition key */
-                            key?: (string|null);
-
                             /** Condition predicate */
                             predicate?: (mesg.types.Process.Node.Filter.Condition.Predicate|null);
 
                             /** Condition value */
-                            value?: (string|null);
+                            value?: (mesg.protobuf.IValue|null);
+
+                            /** Condition ref */
+                            ref?: (mesg.types.Process.Node.IReference|null);
                         }
 
                         /** Represents a Condition. */
@@ -421,14 +363,14 @@ declare namespace mesg {
                              */
                             constructor(properties?: mesg.types.Process.Node.Filter.ICondition);
 
-                            /** Condition key. */
-                            public key: string;
-
                             /** Condition predicate. */
                             public predicate: mesg.types.Process.Node.Filter.Condition.Predicate;
 
                             /** Condition value. */
-                            public value: string;
+                            public value?: (mesg.protobuf.IValue|null);
+
+                            /** Condition ref. */
+                            public ref?: (mesg.types.Process.Node.IReference|null);
                         }
 
                         namespace Condition {
@@ -436,8 +378,77 @@ declare namespace mesg {
                             /** Predicate enum. */
                             enum Predicate {
                                 Unknown = 0,
-                                EQ = 1
+                                EQ = 1,
+                                GT = 2,
+                                GTE = 3,
+                                LT = 4,
+                                LTE = 5,
+                                CONTAINS = 6
                             }
+                        }
+                    }
+
+                    /** Properties of a Reference. */
+                    interface IReference {
+
+                        /** Reference nodeKey */
+                        nodeKey?: (string|null);
+
+                        /** Reference path */
+                        path?: (mesg.types.Process.Node.Reference.IPath|null);
+                    }
+
+                    /** Represents a Reference. */
+                    class Reference implements IReference {
+
+                        /**
+                         * Constructs a new Reference.
+                         * @param [properties] Properties to set
+                         */
+                        constructor(properties?: mesg.types.Process.Node.IReference);
+
+                        /** Reference nodeKey. */
+                        public nodeKey: string;
+
+                        /** Reference path. */
+                        public path?: (mesg.types.Process.Node.Reference.IPath|null);
+                    }
+
+                    namespace Reference {
+
+                        /** Properties of a Path. */
+                        interface IPath {
+
+                            /** Path key */
+                            key?: (string|null);
+
+                            /** Path index */
+                            index?: (number|Long|null);
+
+                            /** Path path */
+                            path?: (mesg.types.Process.Node.Reference.IPath|null);
+                        }
+
+                        /** Represents a Path. */
+                        class Path implements IPath {
+
+                            /**
+                             * Constructs a new Path.
+                             * @param [properties] Properties to set
+                             */
+                            constructor(properties?: mesg.types.Process.Node.Reference.IPath);
+
+                            /** Path key. */
+                            public key: string;
+
+                            /** Path index. */
+                            public index: (number|Long);
+
+                            /** Path path. */
+                            public path?: (mesg.types.Process.Node.Reference.IPath|null);
+
+                            /** Path selector. */
+                            public selector?: ("key"|"index");
                         }
                     }
                 }
@@ -467,6 +478,108 @@ declare namespace mesg {
                     /** Edge dst. */
                     public dst: string;
                 }
+            }
+        }
+
+        /** Namespace protobuf. */
+        namespace protobuf {
+
+            /** Properties of a Struct. */
+            interface IStruct {
+
+                /** Struct fields */
+                fields?: ({ [k: string]: mesg.protobuf.IValue }|null);
+            }
+
+            /** Represents a Struct. */
+            class Struct implements IStruct {
+
+                /**
+                 * Constructs a new Struct.
+                 * @param [properties] Properties to set
+                 */
+                constructor(properties?: mesg.protobuf.IStruct);
+
+                /** Struct fields. */
+                public fields: { [k: string]: mesg.protobuf.IValue };
+            }
+
+            /** Properties of a Value. */
+            interface IValue {
+
+                /** Value nullValue */
+                nullValue?: (mesg.protobuf.NullValue|null);
+
+                /** Value numberValue */
+                numberValue?: (number|null);
+
+                /** Value stringValue */
+                stringValue?: (string|null);
+
+                /** Value boolValue */
+                boolValue?: (boolean|null);
+
+                /** Value structValue */
+                structValue?: (mesg.protobuf.IStruct|null);
+
+                /** Value listValue */
+                listValue?: (mesg.protobuf.IListValue|null);
+            }
+
+            /** Represents a Value. */
+            class Value implements IValue {
+
+                /**
+                 * Constructs a new Value.
+                 * @param [properties] Properties to set
+                 */
+                constructor(properties?: mesg.protobuf.IValue);
+
+                /** Value nullValue. */
+                public nullValue: mesg.protobuf.NullValue;
+
+                /** Value numberValue. */
+                public numberValue: number;
+
+                /** Value stringValue. */
+                public stringValue: string;
+
+                /** Value boolValue. */
+                public boolValue: boolean;
+
+                /** Value structValue. */
+                public structValue?: (mesg.protobuf.IStruct|null);
+
+                /** Value listValue. */
+                public listValue?: (mesg.protobuf.IListValue|null);
+
+                /** Value kind. */
+                public kind?: ("nullValue"|"numberValue"|"stringValue"|"boolValue"|"structValue"|"listValue");
+            }
+
+            /** NullValue enum. */
+            enum NullValue {
+                NULL_VALUE = 0
+            }
+
+            /** Properties of a ListValue. */
+            interface IListValue {
+
+                /** ListValue values */
+                values?: (mesg.protobuf.IValue[]|null);
+            }
+
+            /** Represents a ListValue. */
+            class ListValue implements IListValue {
+
+                /**
+                 * Constructs a new ListValue.
+                 * @param [properties] Properties to set
+                 */
+                constructor(properties?: mesg.protobuf.IListValue);
+
+                /** ListValue values. */
+                public values: mesg.protobuf.IValue[];
             }
         }
 

--- a/packages/api/src/typedef/runner.d.ts
+++ b/packages/api/src/typedef/runner.d.ts
@@ -16,11 +16,14 @@ declare namespace mesg {
                 /** Runner hash */
                 hash?: (Uint8Array|null);
 
-                /** Runner address */
-                address?: (string|null);
+                /** Runner owner */
+                owner?: (string|null);
 
                 /** Runner instanceHash */
                 instanceHash?: (Uint8Array|null);
+
+                /** Runner address */
+                address?: (Uint8Array|null);
             }
 
             /** Represents a Runner. */
@@ -35,11 +38,14 @@ declare namespace mesg {
                 /** Runner hash. */
                 public hash: Uint8Array;
 
-                /** Runner address. */
-                public address: string;
+                /** Runner owner. */
+                public owner: string;
 
                 /** Runner instanceHash. */
                 public instanceHash: Uint8Array;
+
+                /** Runner address. */
+                public address: Uint8Array;
             }
         }
 
@@ -193,8 +199,8 @@ declare namespace mesg {
                     /** Filter instanceHash */
                     instanceHash?: (Uint8Array|null);
 
-                    /** Filter address */
-                    address?: (string|null);
+                    /** Filter owner */
+                    owner?: (string|null);
                 }
 
                 /** Represents a Filter. */
@@ -209,8 +215,8 @@ declare namespace mesg {
                     /** Filter instanceHash. */
                     public instanceHash: Uint8Array;
 
-                    /** Filter address. */
-                    public address: string;
+                    /** Filter owner. */
+                    public owner: string;
                 }
             }
 

--- a/packages/api/src/typedef/service.d.ts
+++ b/packages/api/src/typedef/service.d.ts
@@ -42,6 +42,9 @@ declare namespace mesg {
 
                 /** Service source */
                 source?: (string|null);
+
+                /** Service address */
+                address?: (Uint8Array|null);
             }
 
             /** Represents a Service. */
@@ -82,6 +85,9 @@ declare namespace mesg {
 
                 /** Service source. */
                 public source: string;
+
+                /** Service address. */
+                public address: Uint8Array;
             }
 
             namespace Service {

--- a/packages/compiler/CHANGELOG.md
+++ b/packages/compiler/CHANGELOG.md
@@ -8,6 +8,9 @@
 - [#188](https://github.com/mesg-foundation/js-sdk/pull/188) Compile services in a LCD format
 
 #### Improvements
+
+- [#203](https://github.com/mesg-foundation/js-sdk/pull/203) Add support of any value for filters value (string, boolean or number)
+
 #### Bug fixes
 
 ## [v0.2.0](https://github.com/mesg-foundation/js-sdk/releases/tag/%40mesg%2Fcompiler%400.2.0)

--- a/packages/compiler/src/process.ts
+++ b/packages/compiler/src/process.ts
@@ -1,4 +1,4 @@
-import { IProcess, IMapType, IFilterType, INode, IResultType, IEventType, ITaskType, FilterPredicate, IOutput, IRefPath, IFilterCondition, IFilterValueNullType, IFilterValueStringType, IFilterValueDoubleType, IFilterValueBoolType } from '@mesg/api/lib/process-lcd'
+import { IProcess, IMapType, IFilterType, INode, IResultType, IEventType, ITaskType, FilterPredicate, IOutput, IRefPath, IFilterCondition, IFilterValueNullType, IFilterValueStringType, IFilterValueNumberType, IFilterValueBoolType } from '@mesg/api/lib/process-lcd'
 import decode from './decode'
 import { Process } from './schema/process'
 import validate from './validate'
@@ -122,9 +122,9 @@ const compileMap = async (def: any, opts: any): Promise<IMapType> => {
   }
 }
 
-const compileFilterValue = (def: any): IFilterValueNullType | IFilterValueStringType | IFilterValueDoubleType | IFilterValueBoolType => {
+const compileFilterValue = (def: any): IFilterValueNullType | IFilterValueStringType | IFilterValueNumberType | IFilterValueBoolType => {
   if (def === null) return { type: "mesg.types.Value_NullValue", value: {} }
-  if (typeof def === 'number') return { type: "mesg.types.Value_DoubleValue", value: { double_value: def } }
+  if (typeof def === 'number') return { type: "mesg.types.Value_NumberValue", value: { number_value: def } }
   if (typeof def === 'boolean') return { type: 'mesg.types.Value_BoolValue', value: { bool_value: def } }
   if (typeof def === 'string') return { type: 'mesg.types.Value_StringValue', value: { string_value: def } }
   throw new Error('unsupported filter value')

--- a/packages/compiler/src/process_test.ts
+++ b/packages/compiler/src/process_test.ts
@@ -2,7 +2,7 @@ import { Test } from 'tape'
 import test from 'tape'
 import { readFileSync } from 'fs';
 import compile from './process'
-import { IOutputStringType, IOutputNullType, IOutputDoubleType, IOutputBoolType, IOutputListType, IOutputMapType, IReference, IRefSelectorKey, IRefSelectorIndex } from '@mesg/api/lib/process-lcd';
+import { IOutputStringType, IOutputNullType, IOutputDoubleType, IOutputBoolType, IOutputListType, IOutputMapType, IReference, IRefSelectorKey, IRefSelectorIndex, IFilterValueStringType } from '@mesg/api/lib/process-lcd';
 
 test('valid compilation', async (t: Test) => {
   t.plan(101)
@@ -45,12 +45,12 @@ test('valid compilation', async (t: Test) => {
   // Test filter
   t.equal(filter.key, "node-1")
   t.equal(filter.Type.value.filter.conditions.length, 2)
-  t.equal((filter.Type.value.filter.conditions[0].ref.value.ref.path.Selector as IRefSelectorKey).value.key, "foo")
+  t.equal((filter.Type.value.filter.conditions[0].ref.path.Selector as IRefSelectorKey).value.key, "foo")
   t.equal(filter.Type.value.filter.conditions[0].predicate, 1)
-  t.equal(filter.Type.value.filter.conditions[0].value.stringValue, "bar")
-  t.equal((filter.Type.value.filter.conditions[1].ref.value.ref.path.Selector as IRefSelectorKey).value.key, "hello")
+  t.equal((filter.Type.value.filter.conditions[0].value.Kind as IFilterValueStringType).value.string_value, "bar")
+  t.equal((filter.Type.value.filter.conditions[1].ref.path.Selector as IRefSelectorKey).value.key, "hello")
   t.equal(filter.Type.value.filter.conditions[1].predicate, 1)
-  t.equal(filter.Type.value.filter.conditions[1].value.stringValue, "world")
+  t.equal((filter.Type.value.filter.conditions[1].value.Kind as IFilterValueStringType).value.string_value, "world")
 
   // Test map
   t.equal(mapTask1.key, "task1-inputs")

--- a/packages/compiler/src/process_test.ts
+++ b/packages/compiler/src/process_test.ts
@@ -2,7 +2,7 @@ import { Test } from 'tape'
 import test from 'tape'
 import { readFileSync } from 'fs';
 import compile from './process'
-import { IOutputStringType, IOutputNullType, IOutputDoubleType, IOutputBoolType, IOutputListType, IOutputMapType, IOutputRefType, IRefSelectorKey, IRefSelectorIndex } from '@mesg/api/lib/process-lcd';
+import { IOutputStringType, IOutputNullType, IOutputDoubleType, IOutputBoolType, IOutputListType, IOutputMapType, IReference, IRefSelectorKey, IRefSelectorIndex } from '@mesg/api/lib/process-lcd';
 
 test('valid compilation', async (t: Test) => {
   t.plan(101)
@@ -27,7 +27,7 @@ test('valid compilation', async (t: Test) => {
   if (task2.Type.type !== 'mesg.types.Process_Node_Task_') return t.fail("wrong type")
   if (mapTask3.Type.type !== 'mesg.types.Process_Node_Map_') return t.fail("wrong type")
   if (task3.Type.type !== 'mesg.types.Process_Node_Task_') return t.fail("wrong type")
-  
+
   t.ok(trigger.Type.value.event)
   t.ok(filter.Type.value.filter)
   t.ok(mapTask1.Type.value.map)
@@ -41,16 +41,16 @@ test('valid compilation', async (t: Test) => {
   t.equal(trigger.key, "eventTrigger")
   t.equal(trigger.Type.value.event.eventKey, "eventX")
   t.isEquivalent(trigger.Type.value.event.instanceHash, env.INSTANCE_HASH)
-  
+
   // Test filter
   t.equal(filter.key, "node-1")
   t.equal(filter.Type.value.filter.conditions.length, 2)
-  t.equal(filter.Type.value.filter.conditions[0].key, "foo")
+  t.equal((filter.Type.value.filter.conditions[0].ref.value.ref.path.Selector as IRefSelectorKey).value.key, "foo")
   t.equal(filter.Type.value.filter.conditions[0].predicate, 1)
-  t.equal(filter.Type.value.filter.conditions[0].value, "bar")
-  t.equal(filter.Type.value.filter.conditions[1].key, "hello")
+  t.equal(filter.Type.value.filter.conditions[0].value.stringValue, "bar")
+  t.equal((filter.Type.value.filter.conditions[1].ref.value.ref.path.Selector as IRefSelectorKey).value.key, "hello")
   t.equal(filter.Type.value.filter.conditions[1].predicate, 1)
-  t.equal(filter.Type.value.filter.conditions[1].value, "world")
+  t.equal(filter.Type.value.filter.conditions[1].value.stringValue, "world")
 
   // Test map
   t.equal(mapTask1.key, "task1-inputs")
@@ -68,8 +68,8 @@ test('valid compilation', async (t: Test) => {
   t.equal((list[2].Value as IOutputDoubleType).value.double_const, 42)
   t.equal(((list[3].Value as IOutputMapType).value.map.find(x => x.Key === "foo").Value.Value as IOutputStringType).value.string_const, "bar")
   t.equal(((list[3].Value as IOutputMapType).value.map.find(x => x.Key === "number").Value.Value as IOutputDoubleType).value.double_const, 42)
-  t.equal(((list[4].Value as IOutputRefType).value.ref.path.Selector as IRefSelectorKey).value.key, "dataX")
-  t.equal((list[4].Value as IOutputRefType).value.ref.nodeKey, "node-1")
+  t.equal(((list[4].Value as IReference).value.ref.path.Selector as IRefSelectorKey).value.key, "dataX")
+  t.equal((list[4].Value as IReference).value.ref.nodeKey, "node-1")
   // Test map
   const inputMap = (mapTask1.Type.value.map.find(x => x.Key === "constant_map").Value.Value as IOutputMapType).value.map
   t.equal(Object.keys(inputMap).length, 7)
@@ -82,8 +82,8 @@ test('valid compilation', async (t: Test) => {
   t.equal(((inputMap.find(x => x.Key === "constant_list").Value.Value as IOutputListType).value.list.outputs[1].Value as IOutputNullType).value.null, undefined)
   t.equal(((inputMap.find(x => x.Key === "constant_list").Value.Value as IOutputListType).value.list.outputs[2].Value as IOutputDoubleType).value.double_const, 42)
   t.equal((((inputMap.find(x => x.Key === "constant_list").Value.Value as IOutputListType).value.list.outputs[3].Value as IOutputMapType).value.map.find(x => x.Key === "foo").Value.Value as IOutputStringType).value.string_const, "bar")
-  t.equal((((inputMap.find(x => x.Key === "constant_list").Value.Value as IOutputListType).value.list.outputs[4].Value as IOutputRefType).value.ref.path.Selector as IRefSelectorKey).value.key, "dataX")
-  t.equal(((inputMap.find(x => x.Key === "constant_list").Value.Value as IOutputListType).value.list.outputs[4].Value as IOutputRefType).value.ref.nodeKey, "node-1")
+  t.equal((((inputMap.find(x => x.Key === "constant_list").Value.Value as IOutputListType).value.list.outputs[4].Value as IReference).value.ref.path.Selector as IRefSelectorKey).value.key, "dataX")
+  t.equal(((inputMap.find(x => x.Key === "constant_list").Value.Value as IOutputListType).value.list.outputs[4].Value as IReference).value.ref.nodeKey, "node-1")
   t.equal(((inputMap.find(x => x.Key === "constant_map").Value.Value as IOutputMapType).value.map.find(x => x.Key === "constant_str").Value.Value as IOutputStringType).value.string_const, "constant_str")
   t.equal(((inputMap.find(x => x.Key === "constant_map").Value.Value as IOutputMapType).value.map.find(x => x.Key === "constant_null").Value.Value as IOutputNullType).value.null, undefined)
   t.equal(((inputMap.find(x => x.Key === "constant_map").Value.Value as IOutputMapType).value.map.find(x => x.Key === "constant_number").Value.Value as IOutputDoubleType).value.double_const, 42)
@@ -92,49 +92,49 @@ test('valid compilation', async (t: Test) => {
   t.equal((((inputMap.find(x => x.Key === "constant_map").Value.Value as IOutputMapType).value.map.find(x => x.Key === "constant_list").Value.Value as IOutputListType).value.list.outputs[1].Value as IOutputNullType).value.null, undefined)
   t.equal((((inputMap.find(x => x.Key === "constant_map").Value.Value as IOutputMapType).value.map.find(x => x.Key === "constant_list").Value.Value as IOutputListType).value.list.outputs[2].Value as IOutputDoubleType).value.double_const, 42)
   t.equal(((((inputMap.find(x => x.Key === "constant_map").Value.Value as IOutputMapType).value.map.find(x => x.Key === "constant_list").Value.Value as IOutputListType).value.list.outputs[3].Value as IOutputMapType).value.map.find(x => x.Key === "foo").Value.Value as IOutputStringType).value.string_const, "bar")
-  t.equal(((((inputMap.find(x => x.Key === "constant_map").Value.Value as IOutputMapType).value.map.find(x => x.Key === "constant_list").Value.Value as IOutputListType).value.list.outputs[4].Value as IOutputRefType).value.ref.path.Selector as IRefSelectorKey).value.key, "dataX")
-  t.equal((((inputMap.find(x => x.Key === "constant_map").Value.Value as IOutputMapType).value.map.find(x => x.Key === "constant_list").Value.Value as IOutputListType).value.list.outputs[4].Value as IOutputRefType).value.ref.nodeKey, "node-1")
-  t.equal((((inputMap.find(x => x.Key === "constant_map").Value.Value as IOutputMapType).value.map.find(x => x.Key === "ref").Value.Value as IOutputRefType).value.ref.path.Selector as IRefSelectorKey).value.key, "dataX")
-  t.equal(((inputMap.find(x => x.Key === "constant_map").Value.Value as IOutputMapType).value.map.find(x => x.Key === "ref").Value.Value as IOutputRefType).value.ref.nodeKey, "eventTrigger")
+  t.equal(((((inputMap.find(x => x.Key === "constant_map").Value.Value as IOutputMapType).value.map.find(x => x.Key === "constant_list").Value.Value as IOutputListType).value.list.outputs[4].Value as IReference).value.ref.path.Selector as IRefSelectorKey).value.key, "dataX")
+  t.equal((((inputMap.find(x => x.Key === "constant_map").Value.Value as IOutputMapType).value.map.find(x => x.Key === "constant_list").Value.Value as IOutputListType).value.list.outputs[4].Value as IReference).value.ref.nodeKey, "node-1")
+  t.equal((((inputMap.find(x => x.Key === "constant_map").Value.Value as IOutputMapType).value.map.find(x => x.Key === "ref").Value.Value as IReference).value.ref.path.Selector as IRefSelectorKey).value.key, "dataX")
+  t.equal(((inputMap.find(x => x.Key === "constant_map").Value.Value as IOutputMapType).value.map.find(x => x.Key === "ref").Value.Value as IReference).value.ref.nodeKey, "eventTrigger")
   // Test ref
-  const ref = (mapTask1.Type.value.map.find(x => x.Key === "ref").Value.Value as IOutputRefType).value.ref
+  const ref = (mapTask1.Type.value.map.find(x => x.Key === "ref").Value.Value as IReference).value.ref
   t.equal((ref.path.Selector as IRefSelectorKey).value.key, "dataX")
   t.equal(ref.nodeKey, "eventTrigger")
   // Test ref nested
-  const ref_nested = (mapTask1.Type.value.map.find(x => x.Key === "ref_nested").Value.Value as IOutputRefType).value.ref
+  const ref_nested = (mapTask1.Type.value.map.find(x => x.Key === "ref_nested").Value.Value as IReference).value.ref
   t.equal(ref.nodeKey, "eventTrigger")
   t.equal((ref_nested.path.Selector as IRefSelectorKey).value.key, "dataX")
   t.equal((ref_nested.path.path.Selector as IRefSelectorKey).value.key, "foo")
   t.equal(ref_nested.path.path.path, null)
   // Test ref list
-  const ref_list = (mapTask1.Type.value.map.find(x => x.Key === "ref_list").Value.Value as IOutputRefType).value.ref
+  const ref_list = (mapTask1.Type.value.map.find(x => x.Key === "ref_list").Value.Value as IReference).value.ref
   t.equal(ref.nodeKey, "eventTrigger")
   t.equal((ref_list.path.Selector as IRefSelectorKey).value.key, "dataY")
   t.equal(ref_list.path.path.path, null)
   t.equal((ref_list.path.path.Selector as IRefSelectorIndex).value.index, undefined)
   // Test ref nested_list
-  const ref_nested_list = (mapTask1.Type.value.map.find(x => x.Key === "ref_nested_list").Value.Value as IOutputRefType).value.ref
+  const ref_nested_list = (mapTask1.Type.value.map.find(x => x.Key === "ref_nested_list").Value.Value as IReference).value.ref
   t.equal(ref.nodeKey, "eventTrigger")
   t.equal((ref_nested_list.path.Selector as IRefSelectorKey).value.key, "dataX")
   t.equal((ref_nested_list.path.path.Selector as IRefSelectorKey).value.key, "bar")
   t.equal(ref_nested_list.path.path.path.path, null)
   t.equal((ref_nested_list.path.path.path.Selector as IRefSelectorIndex).value.index, undefined)
   // Test ref list nested
-  const ref_list_nested = (mapTask1.Type.value.map.find(x => x.Key === "ref_list_nested").Value.Value as IOutputRefType).value.ref
+  const ref_list_nested = (mapTask1.Type.value.map.find(x => x.Key === "ref_list_nested").Value.Value as IReference).value.ref
   t.equal(ref.nodeKey, "eventTrigger")
   t.equal((ref_list_nested.path.Selector as IRefSelectorKey).value.key, "dataY")
   t.equal((ref_list_nested.path.path.Selector as IRefSelectorIndex).value.index, undefined)
   t.equal((ref_list_nested.path.path.path.Selector as IRefSelectorKey).value.key, "bar")
   t.equal(ref_list_nested.path.path.path.path, null)
   // Test ref list nested
-  const ref_list_list = (mapTask1.Type.value.map.find(x => x.Key === "ref_list_list").Value.Value as IOutputRefType).value.ref
+  const ref_list_list = (mapTask1.Type.value.map.find(x => x.Key === "ref_list_list").Value.Value as IReference).value.ref
   t.equal(ref.nodeKey, "eventTrigger")
   t.equal((ref_list_list.path.Selector as IRefSelectorKey).value.key, "dataY")
   t.equal((ref_list_list.path.path.Selector as IRefSelectorIndex).value.index, undefined)
   t.equal(ref_list_list.path.path.path.path, null)
   t.equal((ref_list_list.path.path.path.Selector as IRefSelectorIndex).value.index, '1')
   // Test implicit ref
-  const implicit_ref = (mapTask1.Type.value.map.find(x => x.Key === "implicit_ref").Value.Value as IOutputRefType).value.ref
+  const implicit_ref = (mapTask1.Type.value.map.find(x => x.Key === "implicit_ref").Value.Value as IReference).value.ref
   t.equal(implicit_ref.nodeKey, "node-1")
   t.equal((implicit_ref.path.Selector as IRefSelectorKey).value.key, "dataX")
 
@@ -151,12 +151,12 @@ test('valid compilation', async (t: Test) => {
 
   // Test map task3
   t.equal(Object.keys(mapTask3.Type.value.map).length, 3)
-  t.equal((mapTask3.Type.value.map.find(x => x.Key === "a").Value.Value as IOutputRefType).value.ref.nodeKey, "task1")
-  t.equal(((mapTask3.Type.value.map.find(x => x.Key === "a").Value.Value as IOutputRefType).value.ref.path.Selector as IRefSelectorKey).value.key, "resultA")
-  t.equal((mapTask3.Type.value.map.find(x => x.Key === "b").Value.Value as IOutputRefType).value.ref.nodeKey, "task2")
-  t.equal(((mapTask3.Type.value.map.find(x => x.Key === "b").Value.Value as IOutputRefType).value.ref.path.Selector as IRefSelectorKey).value.key, "resultB")
-  t.equal((mapTask3.Type.value.map.find(x => x.Key === "c").Value.Value as IOutputRefType).value.ref.nodeKey, "task2")
-  t.equal(((mapTask3.Type.value.map.find(x => x.Key === "c").Value.Value as IOutputRefType).value.ref.path.Selector as IRefSelectorKey).value.key, "resultC")
+  t.equal((mapTask3.Type.value.map.find(x => x.Key === "a").Value.Value as IReference).value.ref.nodeKey, "task1")
+  t.equal(((mapTask3.Type.value.map.find(x => x.Key === "a").Value.Value as IReference).value.ref.path.Selector as IRefSelectorKey).value.key, "resultA")
+  t.equal((mapTask3.Type.value.map.find(x => x.Key === "b").Value.Value as IReference).value.ref.nodeKey, "task2")
+  t.equal(((mapTask3.Type.value.map.find(x => x.Key === "b").Value.Value as IReference).value.ref.path.Selector as IRefSelectorKey).value.key, "resultB")
+  t.equal((mapTask3.Type.value.map.find(x => x.Key === "c").Value.Value as IReference).value.ref.nodeKey, "task2")
+  t.equal(((mapTask3.Type.value.map.find(x => x.Key === "c").Value.Value as IReference).value.ref.path.Selector as IRefSelectorKey).value.key, "resultC")
 
   // Test task3
   t.isEquivalent(task3.Type.value.task.instanceHash, env.INSTANCE_HASH)

--- a/packages/compiler/src/schema/process.d.ts
+++ b/packages/compiler/src/schema/process.d.ts
@@ -47,7 +47,7 @@ export type Filter = {
        * This interface was referenced by `undefined`'s JSON-Schema definition
        * via the `patternProperty` "^[a-zA-Z0-9_]+$".
        */
-      [k: string]: string;
+      [k: string]: string | number | boolean | null;
     };
     [k: string]: any;
   };

--- a/packages/compiler/src/schema/process.json
+++ b/packages/compiler/src/schema/process.json
@@ -278,7 +278,20 @@
               "additionalProperties": false,
               "patternProperties": {
                 "^[a-zA-Z0-9_]+$": {
-                  "type": "string"
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
                 }
               }
             }


### PR DESCRIPTION
dependency: https://github.com/mesg-foundation/engine/pull/1739
related to:

- https://github.com/mesg-foundation/engine/issues/1734
- https://github.com/mesg-foundation/js-sdk/issues/200

You can now create a filter with conditions that are not only based on `string` value but also `boolean` and `number`.

Now the following filter in a process will be working
```yml
- type: filter
  conditions:
    foo: true
    bar: 42
    hello: "world"
```

We might add the support of `array`/`object` in another PR

What's in this PR:
- [x] update LCD types
- [x] update compiler to use new types
- [x] update the process definition to accept any value for the filter
- [x] update compiler to add any value for the filter
- [x] support reference in the compilation (need to update the definition)

### For another PR

- [ ] update definition to accept reference for filter (https://github.com/mesg-foundation/js-sdk/pull/205)
- [ ] update compiler to add the reference for filter (https://github.com/mesg-foundation/js-sdk/pull/205)

### To test

You can use the following process to test
```yml
name: Test
steps:
  - type: trigger
    instance:
      src: https://github.com/mesg-foundation/service-webhook
    eventKey: request
  - type: filter
    conditions:
      foo: 10
  - type: task
    instance:
      src: https://github.com/mesg-foundation/service-js-function
    taskKey: execute
    inputs:
      code: "module.export = function(value) { return true }"
      inputs:
        foo: 42
```

and run with
```
mesg-cli-dev process:dev ~/Desktop/simple-process.yml --image mesg/engine:local
```

then test with 
```bash
curl -XPOST http://localhost:3005/webhook --data '{"foo": 10}' -H "Content-Type: application/json"
```