### PR TITLE
Proper stop of processes

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -46,6 +46,7 @@ Commands `service:dev` and `process:dev` are automatically start a local environ
 #### Bug fixes
 
 - [#191](https://github.com/mesg-foundation/js-sdk/pull/191) Do not stop the environment if other instances of the CLI rely on it
+- [#211](https://github.com/mesg-foundation/js-sdk/pull/211) Fix issue with network deletion when exiting a process
 
 ## [v0.3.0](https://github.com/mesg-foundation/js-sdk/releases/tag/%40mesg%2Fcli%400.3.0)
 


### PR DESCRIPTION
When stopping a process, because we were deleting the engine's network but not the deployed services, we had an error 
```
(node:10965) UnhandledPromiseRejectionWarning: Error: (HTTP code 403) unexpected - error while removing network: network mesg_engine id 3892f516f01e07b2698a50548a135d2ce5b1e7b7b81f4f3faa6203c9ca7c24cd has active endpoints
```

Now the `process:dev` properly delete the process and stop all the services started for this process