### PR TITLE
Set grace period to 60sec to stop engine

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -42,6 +42,7 @@ Commands `service:dev` and `process:dev` are automatically start a local environ
 - [#197](https://github.com/mesg-foundation/js-sdk/pull/197) State of the local chain in the `dataDir` (https://oclif.io/docs/config)
 - [#199](https://github.com/mesg-foundation/js-sdk/pull/199) Use api helper to get the hash of a created service/process
 - [#199](https://github.com/mesg-foundation/js-sdk/pull/199) Run engine and service with the `@mesg/runner` library
+- [#212](https://github.com/mesg-foundation/js-sdk/pull/212) Set grace period to 60sec to stop engine
 
 #### Bug fixes
 

--- a/packages/cli/src/utils/environment-tasks.ts
+++ b/packages/cli/src/utils/environment-tasks.ts
@@ -53,7 +53,9 @@ export const stop: ListrTask<IStop> = {
         const containers = await listContainers({ label: [engineLabel] })
         if (containers.length === 0) throw new Error('Cannot find engine')
         const container = containers[0]
-        await container.stop()
+        await container.stop({
+          "t": 60, // tell docker to wait for the container to stop gracefully within 60sec.
+        })
         await container.delete()
         const network = await findNetwork(engineName)
         if (network) await network.remove()


### PR DESCRIPTION
Set grace period to 60sec to give enough time to the engine to stop gracefully.
The default in docker is only 10sec.

closes https://github.com/mesg-foundation/js-sdk/issues/172
related to https://github.com/mesg-foundation/engine/issues/1634

The engine's log should output all on this when stopping:
```
INFO[0022] stopping running services                     module=main
INFO[0022] ABCIQuery                                     data= module=rpc path=custom/runner/list result="value:\"null\" height:77 "
INFO[0022] cleanup container                             module=main
INFO[0022] stopping lcd server                           module=main
INFO[0022] RPC HTTP server stopped                       err="accept tcp [::]:1317: use of closed network connection"
WARN[0022] accept tcp [::]:1317: use of closed network connection  module=main
INFO[0022] stopping orchestrator                         module=main
INFO[0022] stopping grpc server                          module=main
INFO[0022] stopping tendermint                           module=main
INFO[0022] Stopping Node                                 impl=Node
INFO[0022] Stopping Node
INFO[0022] Stopping EventBus                             impl=EventBus module=events
INFO[0022] Stopping PubSub                               impl=PubSub module=pubsub
INFO[0022] Stopping IndexerService                       impl=IndexerService module=txindex
INFO[0022] Stopping P2P Switch                           impl="P2P Switch" module=p2p
INFO[0022] Stopping Reactor                              impl=Reactor module=mempool
INFO[0022] Stopping BlockchainReactor                    impl=BlockchainReactor module=blockchain
ERRO[0022] Not stopping BlockPool -- have not been started yet  impl=BlockPool module=blockchain
INFO[0022] Stopping Reactor                              impl=ConsensusReactor module=consensus
INFO[0022] Stopping State                                impl=ConsensusState module=consensus
INFO[0022] Stopping TimeoutTicker                        impl=TimeoutTicker module=consensus
INFO[0022] Stopping baseWAL                              impl=baseWAL module=consensus wal=/root/.mesg/tendermint/data/cs.wal/wal
INFO[0022] Stopping Group                                impl=Group module=consensus wal=/root/.mesg/tendermint/data/cs.wal/wal
INFO[0022] Stopping Reactor                              impl=Reactor module=evidence
INFO[0022] Stopping Reactor                              impl=Reactor module=pex
INFO[0022] Stopping AddrBook                             book=/root/.mesg/tendermint/config/addrbook.json impl=AddrBook module=p2p
INFO[0022] Closing rpc listener                          listener="&{0xc00009c060 0xc000083140 {0 {0 0}} 0xc0000831a0}"
INFO[0022] RPC HTTP server stopped                       err="accept tcp [::]:26657: use of closed network connection" module=rpc-server
```

if those logs don't show up, the engine has been killed and the databases might be corrupted (happen sometime when syncing with the network)