### PR TITLE
Merge flags image and tag to version

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -47,6 +47,7 @@ Commands `service:dev` and `process:dev` are automatically start a local environ
 
 - [#191](https://github.com/mesg-foundation/js-sdk/pull/191) Do not stop the environment if other instances of the CLI rely on it
 - [#211](https://github.com/mesg-foundation/js-sdk/pull/211) Fix issue with network deletion when exiting a process
+- [#213](https://github.com/mesg-foundation/js-sdk/pull/213) Fix unused `tag` flag and replace with `version`
 
 ## [v0.3.0](https://github.com/mesg-foundation/js-sdk/releases/tag/%40mesg%2Fcli%400.3.0)
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -47,7 +47,7 @@ Commands `service:dev` and `process:dev` are automatically start a local environ
 
 - [#191](https://github.com/mesg-foundation/js-sdk/pull/191) Do not stop the environment if other instances of the CLI rely on it
 - [#211](https://github.com/mesg-foundation/js-sdk/pull/211) Fix issue with network deletion when exiting a process
-- [#213](https://github.com/mesg-foundation/js-sdk/pull/213) Fix unused `tag` flag and replace with `version`
+- [#213](https://github.com/mesg-foundation/js-sdk/pull/213) Merge flags `image` and `tag` to `version`
 
 ## [v0.3.0](https://github.com/mesg-foundation/js-sdk/releases/tag/%40mesg%2Fcli%400.3.0)
 

--- a/packages/cli/src/commands/process/dev.ts
+++ b/packages/cli/src/commands/process/dev.ts
@@ -21,8 +21,7 @@ export default class Dev extends Command {
   static description = 'Run a process in a local development environment'
 
   static flags = {
-    image: flags.string({ name: 'Engine image', default: 'mesg/engine' }),
-    tag: flags.string({ name: 'Engine version', default: version.engine }),
+    version: flags.string({ name: 'Engine version', default: version.engine }),
     pull: flags.boolean({ name: 'Force to pull the docker image', default: false }),
     env: flags.string({
       description: 'Environment variables to inject to the process',
@@ -79,9 +78,8 @@ export default class Dev extends Command {
     ])
     const { mnemonic } = await tasks.run({
       configDir: this.config.dataDir,
-      image: flags.image,
       pull: flags.pull,
-      tag: flags.tag,
+      version: flags.version,
       endpoint: this.lcdEndpoint,
     })
 

--- a/packages/cli/src/commands/service/dev.ts
+++ b/packages/cli/src/commands/service/dev.ts
@@ -25,8 +25,7 @@ export default class Dev extends Command {
   static description = 'Run a service in a local development environment'
 
   static flags = {
-    image: flags.string({ name: 'Engine image', default: 'mesg/engine' }),
-    tag: flags.string({ name: 'Engine version', default: version.engine }),
+    version: flags.string({ name: 'Engine version', default: version.engine }),
     pull: flags.boolean({ name: 'Force to pull the docker image', default: false }),
     env: flags.string({
       description: 'Environment variables to inject to the service',
@@ -121,9 +120,8 @@ export default class Dev extends Command {
     ])
     const res = await tasks.run({
       configDir: this.config.dataDir,
-      image: flags.image,
       pull: flags.pull,
-      tag: flags.tag,
+      version: flags.version,
       endpoint: this.lcdEndpoint,
     })
 

--- a/packages/cli/src/utils/environment-tasks.ts
+++ b/packages/cli/src/utils/environment-tasks.ts
@@ -6,6 +6,7 @@ import { getOrGenerateAccount, write, clear } from "./config"
 import fetch from "node-fetch"
 
 const pidFilename = 'pid.json'
+const image = 'mesg/engine'
 
 const pids = (path: string): number[] => existsSync(join(path, pidFilename))
   ? JSON.parse(readFileSync(join(path, pidFilename)).toString()).map((x: any) => parseInt(x, 10))
@@ -71,7 +72,7 @@ export const stop: ListrTask<IStop> = {
   ])
 }
 
-export type IStart = { configDir: string, pull: boolean, image: string, tag: string, endpoint: string, mnemonic?: string }
+export type IStart = { configDir: string, pull: boolean, version: string, endpoint: string, mnemonic?: string }
 export const start: ListrTask<IStart> = {
   title: 'Starting environment',
   task: () => new Listr([
@@ -91,8 +92,8 @@ export const start: ListrTask<IStart> = {
     },
     {
       title: 'Updating the Engine image',
-      skip: async ctx => !ctx.pull && await hasImage(ctx.image),
-      task: ctx => fetchImageTag(ctx.image, ctx.tag)
+      skip: async ctx => !ctx.pull && await hasImage(`${image}:${ctx.version}`),
+      task: ctx => fetchImageTag(image, ctx.version)
     },
     {
       title: 'Starting the Engine',
@@ -103,7 +104,7 @@ export const start: ListrTask<IStart> = {
             mnemonic: ctx.mnemonic
           }
         })
-        return createContainer(ctx.image, ctx.configDir)
+        return createContainer(`${image}:${ctx.version}`, ctx.configDir)
       }
     },
     {


### PR DESCRIPTION
The `tag` flag was not used in some cases and quite confusing. I removed the `image` flag and renamed `tag` to `version`.
This way now if we want to start a specific engine, we need to stop the current engine and run a command like:
```
mesg-cli service:dev xxx --version local (--pull)
```