### PR TITLE
Filter based on new events

### DIFF
--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -16,7 +16,7 @@
 - [#199](https://github.com/mesg-foundation/js-sdk/pull/199) Add create/delete/hash messages for runners
 - [#205](https://github.com/mesg-foundation/js-sdk/pull/205) Update LCD types and add process filters value and reference
 - [#207](https://github.com/mesg-foundation/js-sdk/pull/207) Update messages for the api and add integration tests
-- [#](https://github.com/mesg-foundation/js-sdk/pull/) Update filtering of transaction logs based on the new engine's events
+- [#218](https://github.com/mesg-foundation/js-sdk/pull/218) Update filtering of transaction logs based on the new engine's events
 
 #### Bug fixes
 

--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [#199](https://github.com/mesg-foundation/js-sdk/pull/199) Add create/delete/hash messages for runners
 - [#205](https://github.com/mesg-foundation/js-sdk/pull/205) Update LCD types and add process filters value and reference
 - [#207](https://github.com/mesg-foundation/js-sdk/pull/207) Update messages for the api and add integration tests
+- [#](https://github.com/mesg-foundation/js-sdk/pull/) Update filtering of transaction logs based on the new engine's events
 
 #### Bug fixes
 

--- a/packages/api/src/util/txevent.ts
+++ b/packages/api/src/util/txevent.ts
@@ -1,13 +1,13 @@
 import { TxResult } from "../lcd";
 
 const isAction = (action: string) => (x: any) => x.key === 'action' && x.value === action
-const isModule = (module: string) => (x: any) => x.key === 'module' && x.value.toLowerCase() === module.toLowerCase()
+const isModule = (module: string) => (x: any) => x.type === module.toLowerCase()
 const isHash = (x: any) => x.key === 'hash'
 
 export const findHash = (txResult: TxResult, resourceType: 'Service' | 'Process' | 'Runner'): string[] => {
   return txResult.logs
-    .map(x => x.events.find(y => y.type === 'message').attributes)
-    .filter(x => x.find(isAction(`Create${resourceType}`)) && x.find(isModule(resourceType)) && x.find(isHash))
+    .map(x => x.events.find(isModule(resourceType)).attributes)
+    .filter(x => x.find(isAction('created')) && x.find(isHash))
     .map(x => x.find(isHash))
     .filter(x => !!x)
     .map(x => x.value)


### PR DESCRIPTION
Dependency: https://github.com/mesg-foundation/engine/pull/1769

Read data from the events of a transaction based on the new events of the engine.
Now the events are not read from the `message` but directly from the resource event.