### PR TITLE
Skip the start of the engine if running already

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -44,6 +44,7 @@ Commands `service:dev` and `process:dev` are automatically start a local environ
 - [#199](https://github.com/mesg-foundation/js-sdk/pull/199) Run engine and service with the `@mesg/runner` library
 - [#198](https://github.com/mesg-foundation/js-sdk/198) Add command `dev` for support of MESG project created with the MESG Framework. This creates all the services/processes needed for your application.
 - [#216](https://github.com/mesg-foundation/js-sdk/pull/216) Add authentication to services
+- [#](https://github.com/mesg-foundation/js-sdk/pull/) Improve engine start up detection
 
 #### Bug fixes
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -44,7 +44,7 @@ Commands `service:dev` and `process:dev` are automatically start a local environ
 - [#199](https://github.com/mesg-foundation/js-sdk/pull/199) Run engine and service with the `@mesg/runner` library
 - [#198](https://github.com/mesg-foundation/js-sdk/198) Add command `dev` for support of MESG project created with the MESG Framework. This creates all the services/processes needed for your application.
 - [#216](https://github.com/mesg-foundation/js-sdk/pull/216) Add authentication to services
-- [#](https://github.com/mesg-foundation/js-sdk/pull/) Improve engine start up detection
+- [#219](https://github.com/mesg-foundation/js-sdk/pull/219) Improve engine start up detection
 
 #### Bug fixes
 

--- a/packages/cli/src/utils/environment-tasks.ts
+++ b/packages/cli/src/utils/environment-tasks.ts
@@ -97,7 +97,7 @@ export const start: ListrTask<IStart> = {
     },
     {
       title: 'Starting the Engine',
-      skip: async () => (await listContainers({ label: [engineLabel] })).length > 0,
+      skip: async ctx => await isRunning(ctx.endpoint) || (await listContainers({ label: [engineLabel] })).length > 0,
       task: ctx => {
         write(ctx.configDir, {
           account: {


### PR DESCRIPTION
Small PR to not start the engine if it is already running outside of docker (or with different name in docker)