### PR TITLE
Expose sign and derive mnemonic functions

### DIFF
--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -16,7 +16,7 @@
 - [#199](https://github.com/mesg-foundation/js-sdk/pull/199) Add create/delete/hash messages for runners
 - [#205](https://github.com/mesg-foundation/js-sdk/pull/205) Update LCD types and add process filters value and reference
 - [#207](https://github.com/mesg-foundation/js-sdk/pull/207) Update messages for the api and add integration tests
-- [#](https://github.com/mesg-foundation/js-sdk/pull/) Expose crypto functions `Transaction.sign` and `Account.deriveMnemonic`
+- [#220](https://github.com/mesg-foundation/js-sdk/pull/220) Expose crypto functions `Transaction.sign` and `Account.deriveMnemonic`
 
 #### Bug fixes
 

--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [#199](https://github.com/mesg-foundation/js-sdk/pull/199) Add create/delete/hash messages for runners
 - [#205](https://github.com/mesg-foundation/js-sdk/pull/205) Update LCD types and add process filters value and reference
 - [#207](https://github.com/mesg-foundation/js-sdk/pull/207) Update messages for the api and add integration tests
+- [#](https://github.com/mesg-foundation/js-sdk/pull/) Expose crypto functions `Transaction.sign` and `Account.deriveMnemonic`
 
 #### Bug fixes
 

--- a/packages/api/src/account-lcd.ts
+++ b/packages/api/src/account-lcd.ts
@@ -22,17 +22,17 @@ export type IMsgTransfer = {
   amount: ICoin[];
 }
 
-const deriveMnemonic = (mnemonic: string, path: string = defaultHDPath): BIP32Interface => {
-  if (!validateMnemonic(mnemonic)) throw new Error('invalid mnemonic')
-  const seed = mnemonicToSeedSync(mnemonic)
-  const masterKey = fromSeed(seed)
-  return masterKey.derivePath(path)
-}
-
 export default class Account extends LCDClient {
+  
+  static deriveMnemonic(mnemonic: string, path: string = defaultHDPath): BIP32Interface {
+    if (!validateMnemonic(mnemonic)) throw new Error('invalid mnemonic')
+    const seed = mnemonicToSeedSync(mnemonic)
+    const masterKey = fromSeed(seed)
+    return masterKey.derivePath(path)
+  }
 
   static getPrivateKey(mnemonic: string, path?: string): Buffer {
-    return deriveMnemonic(mnemonic, path).privateKey
+    return Account.deriveMnemonic(mnemonic, path).privateKey
   }
 
   static generateMnemonic(): string {
@@ -53,7 +53,7 @@ export default class Account extends LCDClient {
   }
 
   async import(mnemonic: string, path?: string, prefix: string = bech32Prefix): Promise<IAccount> {
-    const child = await deriveMnemonic(mnemonic, path)
+    const child = await Account.deriveMnemonic(mnemonic, path)
     const address = encode(prefix, toWords(child.identifier))
     return this.get(address)
   }

--- a/packages/api/src/transaction.ts
+++ b/packages/api/src/transaction.ts
@@ -44,6 +44,14 @@ export default class Transaction {
   private _stdTx: IStdTx
   public raw: ITx
 
+  static sign(message: string, ecpairPriv: Buffer): any {
+    const hash = createHash('sha256')
+      .update(message)
+      .digest('hex')
+    const buf = Buffer.from(hash, 'hex')
+    return ecdsaSign(buf, ecpairPriv)
+  }
+
   constructor(stdTx: IStdTx) {
     if (!stdTx.msgs.length) throw new Error('you need at least one msg in your transaction')
     this._stdTx = sortObject(stdTx)
@@ -61,11 +69,7 @@ export default class Transaction {
 
   sign(ecpairPriv: Buffer): Transaction {
     const data = JSON.stringify(sortObject(this._stdTx))
-    const hash = createHash('sha256')
-      .update(data)
-      .digest('hex')
-    const buf = Buffer.from(hash, 'hex')
-    const { signature } = ecdsaSign(buf, ecpairPriv)
+    const { signature } = Transaction.sign(data, ecpairPriv)
     const pubKeyByte = publicKeyCreate(ecpairPriv)
 
     this.raw.signatures.push({

--- a/packages/runner/package-lock.json
+++ b/packages/runner/package-lock.json
@@ -4,17 +4,98 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@grpc/proto-loader": {
+			"version": "0.5.4",
+			"resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.5.4.tgz",
+			"integrity": "sha512-HTM4QpI9B2XFkPz7pjwMyMgZchJ93TVkL3kWPW8GDMDKYxsMnmf4w2TNMJK7+KNiYHS5cJrCEAFlF+AwtXWVPA==",
+			"requires": {
+				"lodash.camelcase": "^4.3.0",
+				"protobufjs": "^6.8.6"
+			}
+		},
+		"@mesg/api": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@mesg/api/-/api-0.2.0.tgz",
+			"integrity": "sha512-1MPtrHcHsljpuqig/AjLTTYYREGYFu40PxDfRh3CT2F99qsNCVx8Edk59+pFfCWA4qB2JvstjktEkUClbpLyRw==",
+			"requires": {
+				"@grpc/proto-loader": "^0.5.3",
+				"base-x": "^3.0.7",
+				"grpc": "^1.24.2",
+				"protobufjs": "^6.8.8"
+			}
+		},
+		"@protobufjs/aspromise": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+			"integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78="
+		},
+		"@protobufjs/base64": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+			"integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+		},
+		"@protobufjs/codegen": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+			"integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+		},
+		"@protobufjs/eventemitter": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+			"integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A="
+		},
+		"@protobufjs/fetch": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+			"integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
+			"requires": {
+				"@protobufjs/aspromise": "^1.1.1",
+				"@protobufjs/inquire": "^1.1.0"
+			}
+		},
+		"@protobufjs/float": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+			"integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E="
+		},
+		"@protobufjs/inquire": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+			"integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik="
+		},
+		"@protobufjs/path": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+			"integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0="
+		},
+		"@protobufjs/pool": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+			"integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q="
+		},
+		"@protobufjs/utf8": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+			"integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
+		},
+		"@types/bytebuffer": {
+			"version": "5.0.40",
+			"resolved": "https://registry.npmjs.org/@types/bytebuffer/-/bytebuffer-5.0.40.tgz",
+			"integrity": "sha512-h48dyzZrPMz25K6Q4+NCwWaxwXany2FhQg/ErOcdZS1ZpsaDnDMZg8JYLMTGz7uvXKrcKGJUZJlZObyfgdaN9g==",
+			"requires": {
+				"@types/long": "*",
+				"@types/node": "*"
+			}
+		},
 		"@types/long": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
-			"integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w==",
-			"dev": true
+			"integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
 		},
 		"@types/node": {
 			"version": "13.9.2",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.2.tgz",
-			"integrity": "sha512-bnoqK579sAYrQbp73wwglccjJ4sfRdKU7WNEZ5FW4K2U6Kc0/eZ5kvXG0JKsEKFB50zrFmfFt52/cvBbZa7eXg==",
-			"dev": true
+			"integrity": "sha512-bnoqK579sAYrQbp73wwglccjJ4sfRdKU7WNEZ5FW4K2U6Kc0/eZ5kvXG0JKsEKFB50zrFmfFt52/cvBbZa7eXg=="
 		},
 		"@types/node-fetch": {
 			"version": "2.5.5",
@@ -24,15 +105,6 @@
 			"requires": {
 				"@types/node": "*",
 				"form-data": "^3.0.0"
-			}
-		},
-		"@types/secp256k1": {
-			"version": "3.5.3",
-			"resolved": "https://registry.npmjs.org/@types/secp256k1/-/secp256k1-3.5.3.tgz",
-			"integrity": "sha512-NGcsPDR0P+Q71O63e2ayshmiZGAwCOa/cLJzOIuhOiDvmbvrCIiVtEpqdCJGogG92Bnr6tw/6lqVBsRMEl15OQ==",
-			"dev": true,
-			"requires": {
-				"@types/node": "*"
 			}
 		},
 		"@types/tape": {
@@ -53,11 +125,25 @@
 				"through": ">=2.2.7 <3"
 			}
 		},
+		"ansi-regex": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+		},
 		"arg": {
 			"version": "4.1.3",
 			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
 			"integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
 			"dev": true
+		},
+		"ascli": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/ascli/-/ascli-1.0.1.tgz",
+			"integrity": "sha1-vPpZdKYvGOgcq660lzKrSoj5Brw=",
+			"requires": {
+				"colour": "~0.7.1",
+				"optjs": "~3.2.2"
+			}
 		},
 		"asynckit": {
 			"version": "0.4.0",
@@ -71,10 +157,13 @@
 			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
 			"dev": true
 		},
-		"bn.js": {
-			"version": "4.11.8",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-			"integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+		"base-x": {
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz",
+			"integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
+			"requires": {
+				"safe-buffer": "^5.0.1"
+			}
 		},
 		"brace-expansion": {
 			"version": "1.1.11",
@@ -86,16 +175,51 @@
 				"concat-map": "0.0.1"
 			}
 		},
-		"brorand": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-			"integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
-		},
 		"buffer-from": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
 			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
 			"dev": true
+		},
+		"bytebuffer": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/bytebuffer/-/bytebuffer-5.0.1.tgz",
+			"integrity": "sha1-WC7qSxqHO20CCkjVjfhfC7ps/d0=",
+			"requires": {
+				"long": "~3"
+			},
+			"dependencies": {
+				"long": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
+					"integrity": "sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s="
+				}
+			}
+		},
+		"camelcase": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+			"integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
+		},
+		"cliui": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+			"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+			"requires": {
+				"string-width": "^1.0.1",
+				"strip-ansi": "^3.0.1",
+				"wrap-ansi": "^2.0.0"
+			}
+		},
+		"code-point-at": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+		},
+		"colour": {
+			"version": "0.7.1",
+			"resolved": "https://registry.npmjs.org/colour/-/colour-0.7.1.tgz",
+			"integrity": "sha1-nLFpkX7F0SwHNtPoaFdG3xyt93g="
 		},
 		"combined-stream": {
 			"version": "1.0.8",
@@ -124,6 +248,11 @@
 			"requires": {
 				"ms": "^2.1.1"
 			}
+		},
+		"decamelize": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
 		},
 		"deep-equal": {
 			"version": "1.1.1",
@@ -199,20 +328,6 @@
 			"dev": true,
 			"requires": {
 				"minimatch": "^3.0.4"
-			}
-		},
-		"elliptic": {
-			"version": "6.5.2",
-			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
-			"integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
-			"requires": {
-				"bn.js": "^4.4.0",
-				"brorand": "^1.0.1",
-				"hash.js": "^1.0.0",
-				"hmac-drbg": "^1.0.0",
-				"inherits": "^2.0.1",
-				"minimalistic-assert": "^1.0.0",
-				"minimalistic-crypto-utils": "^1.0.0"
 			}
 		},
 		"es-abstract": {
@@ -291,6 +406,435 @@
 				"path-is-absolute": "^1.0.0"
 			}
 		},
+		"grpc": {
+			"version": "1.24.2",
+			"resolved": "https://registry.npmjs.org/grpc/-/grpc-1.24.2.tgz",
+			"integrity": "sha512-EG3WH6AWMVvAiV15d+lr+K77HJ/KV/3FvMpjKjulXHbTwgDZkhkcWbwhxFAoTdxTkQvy0WFcO3Nog50QBbHZWw==",
+			"requires": {
+				"@types/bytebuffer": "^5.0.40",
+				"lodash.camelcase": "^4.3.0",
+				"lodash.clone": "^4.5.0",
+				"nan": "^2.13.2",
+				"node-pre-gyp": "^0.14.0",
+				"protobufjs": "^5.0.3"
+			},
+			"dependencies": {
+				"abbrev": {
+					"version": "1.1.1",
+					"bundled": true
+				},
+				"ansi-regex": {
+					"version": "2.1.1",
+					"bundled": true
+				},
+				"aproba": {
+					"version": "1.2.0",
+					"bundled": true
+				},
+				"are-we-there-yet": {
+					"version": "1.1.5",
+					"bundled": true,
+					"requires": {
+						"delegates": "^1.0.0",
+						"readable-stream": "^2.0.6"
+					}
+				},
+				"balanced-match": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"brace-expansion": {
+					"version": "1.1.11",
+					"bundled": true,
+					"requires": {
+						"balanced-match": "^1.0.0",
+						"concat-map": "0.0.1"
+					}
+				},
+				"chownr": {
+					"version": "1.1.3",
+					"bundled": true
+				},
+				"code-point-at": {
+					"version": "1.1.0",
+					"bundled": true
+				},
+				"concat-map": {
+					"version": "0.0.1",
+					"bundled": true
+				},
+				"console-control-strings": {
+					"version": "1.1.0",
+					"bundled": true
+				},
+				"core-util-is": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"debug": {
+					"version": "3.2.6",
+					"bundled": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"deep-extend": {
+					"version": "0.6.0",
+					"bundled": true
+				},
+				"delegates": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"detect-libc": {
+					"version": "1.0.3",
+					"bundled": true
+				},
+				"fs-minipass": {
+					"version": "1.2.7",
+					"bundled": true,
+					"requires": {
+						"minipass": "^2.6.0"
+					}
+				},
+				"fs.realpath": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"gauge": {
+					"version": "2.7.4",
+					"bundled": true,
+					"requires": {
+						"aproba": "^1.0.3",
+						"console-control-strings": "^1.0.0",
+						"has-unicode": "^2.0.0",
+						"object-assign": "^4.1.0",
+						"signal-exit": "^3.0.0",
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1",
+						"wide-align": "^1.1.0"
+					}
+				},
+				"glob": {
+					"version": "7.1.4",
+					"bundled": true,
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				},
+				"has-unicode": {
+					"version": "2.0.1",
+					"bundled": true
+				},
+				"iconv-lite": {
+					"version": "0.4.24",
+					"bundled": true,
+					"requires": {
+						"safer-buffer": ">= 2.1.2 < 3"
+					}
+				},
+				"ignore-walk": {
+					"version": "3.0.3",
+					"bundled": true,
+					"requires": {
+						"minimatch": "^3.0.4"
+					}
+				},
+				"inflight": {
+					"version": "1.0.6",
+					"bundled": true,
+					"requires": {
+						"once": "^1.3.0",
+						"wrappy": "1"
+					}
+				},
+				"inherits": {
+					"version": "2.0.4",
+					"bundled": true
+				},
+				"ini": {
+					"version": "1.3.5",
+					"bundled": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"number-is-nan": "^1.0.0"
+					}
+				},
+				"isarray": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"minimatch": {
+					"version": "3.0.4",
+					"bundled": true,
+					"requires": {
+						"brace-expansion": "^1.1.7"
+					}
+				},
+				"minimist": {
+					"version": "1.2.0",
+					"bundled": true
+				},
+				"minipass": {
+					"version": "2.9.0",
+					"bundled": true,
+					"requires": {
+						"safe-buffer": "^5.1.2",
+						"yallist": "^3.0.0"
+					}
+				},
+				"minizlib": {
+					"version": "1.3.3",
+					"bundled": true,
+					"requires": {
+						"minipass": "^2.9.0"
+					}
+				},
+				"mkdirp": {
+					"version": "0.5.1",
+					"bundled": true,
+					"requires": {
+						"minimist": "0.0.8"
+					},
+					"dependencies": {
+						"minimist": {
+							"version": "0.0.8",
+							"bundled": true
+						}
+					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"bundled": true
+				},
+				"needle": {
+					"version": "2.4.0",
+					"bundled": true,
+					"requires": {
+						"debug": "^3.2.6",
+						"iconv-lite": "^0.4.4",
+						"sax": "^1.2.4"
+					}
+				},
+				"node-pre-gyp": {
+					"version": "0.14.0",
+					"bundled": true,
+					"requires": {
+						"detect-libc": "^1.0.2",
+						"mkdirp": "^0.5.1",
+						"needle": "^2.2.1",
+						"nopt": "^4.0.1",
+						"npm-packlist": "^1.1.6",
+						"npmlog": "^4.0.2",
+						"rc": "^1.2.7",
+						"rimraf": "^2.6.1",
+						"semver": "^5.3.0",
+						"tar": "^4.4.2"
+					}
+				},
+				"nopt": {
+					"version": "4.0.1",
+					"bundled": true,
+					"requires": {
+						"abbrev": "1",
+						"osenv": "^0.1.4"
+					}
+				},
+				"npm-bundled": {
+					"version": "1.0.6",
+					"bundled": true
+				},
+				"npm-packlist": {
+					"version": "1.4.6",
+					"bundled": true,
+					"requires": {
+						"ignore-walk": "^3.0.1",
+						"npm-bundled": "^1.0.1"
+					}
+				},
+				"npmlog": {
+					"version": "4.1.2",
+					"bundled": true,
+					"requires": {
+						"are-we-there-yet": "~1.1.2",
+						"console-control-strings": "~1.1.0",
+						"gauge": "~2.7.3",
+						"set-blocking": "~2.0.0"
+					}
+				},
+				"number-is-nan": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"object-assign": {
+					"version": "4.1.1",
+					"bundled": true
+				},
+				"once": {
+					"version": "1.4.0",
+					"bundled": true,
+					"requires": {
+						"wrappy": "1"
+					}
+				},
+				"os-homedir": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"os-tmpdir": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"osenv": {
+					"version": "0.1.5",
+					"bundled": true,
+					"requires": {
+						"os-homedir": "^1.0.0",
+						"os-tmpdir": "^1.0.0"
+					}
+				},
+				"path-is-absolute": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"process-nextick-args": {
+					"version": "2.0.1",
+					"bundled": true
+				},
+				"protobufjs": {
+					"version": "5.0.3",
+					"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-5.0.3.tgz",
+					"integrity": "sha512-55Kcx1MhPZX0zTbVosMQEO5R6/rikNXd9b6RQK4KSPcrSIIwoXTtebIczUrXlwaSrbz4x8XUVThGPob1n8I4QA==",
+					"requires": {
+						"ascli": "~1",
+						"bytebuffer": "~5",
+						"glob": "^7.0.5",
+						"yargs": "^3.10.0"
+					}
+				},
+				"rc": {
+					"version": "1.2.8",
+					"bundled": true,
+					"requires": {
+						"deep-extend": "^0.6.0",
+						"ini": "~1.3.0",
+						"minimist": "^1.2.0",
+						"strip-json-comments": "~2.0.1"
+					}
+				},
+				"readable-stream": {
+					"version": "2.3.6",
+					"bundled": true,
+					"requires": {
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.3",
+						"isarray": "~1.0.0",
+						"process-nextick-args": "~2.0.0",
+						"safe-buffer": "~5.1.1",
+						"string_decoder": "~1.1.1",
+						"util-deprecate": "~1.0.1"
+					}
+				},
+				"rimraf": {
+					"version": "2.7.1",
+					"bundled": true,
+					"requires": {
+						"glob": "^7.1.3"
+					}
+				},
+				"safe-buffer": {
+					"version": "5.1.2",
+					"bundled": true
+				},
+				"safer-buffer": {
+					"version": "2.1.2",
+					"bundled": true
+				},
+				"sax": {
+					"version": "1.2.4",
+					"bundled": true
+				},
+				"semver": {
+					"version": "5.7.1",
+					"bundled": true
+				},
+				"set-blocking": {
+					"version": "2.0.0",
+					"bundled": true
+				},
+				"signal-exit": {
+					"version": "3.0.2",
+					"bundled": true
+				},
+				"string-width": {
+					"version": "1.0.2",
+					"bundled": true,
+					"requires": {
+						"code-point-at": "^1.0.0",
+						"is-fullwidth-code-point": "^1.0.0",
+						"strip-ansi": "^3.0.0"
+					}
+				},
+				"string_decoder": {
+					"version": "1.1.1",
+					"bundled": true,
+					"requires": {
+						"safe-buffer": "~5.1.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"bundled": true,
+					"requires": {
+						"ansi-regex": "^2.0.0"
+					}
+				},
+				"strip-json-comments": {
+					"version": "2.0.1",
+					"bundled": true
+				},
+				"tar": {
+					"version": "4.4.13",
+					"bundled": true,
+					"requires": {
+						"chownr": "^1.1.1",
+						"fs-minipass": "^1.2.5",
+						"minipass": "^2.8.6",
+						"minizlib": "^1.2.1",
+						"mkdirp": "^0.5.0",
+						"safe-buffer": "^5.1.2",
+						"yallist": "^3.0.3"
+					}
+				},
+				"util-deprecate": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"wide-align": {
+					"version": "1.1.3",
+					"bundled": true,
+					"requires": {
+						"string-width": "^1.0.2 || 2"
+					}
+				},
+				"wrappy": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"yallist": {
+					"version": "3.1.1",
+					"bundled": true
+				}
+			}
+		},
 		"has": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -306,25 +850,6 @@
 			"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
 			"dev": true
 		},
-		"hash.js": {
-			"version": "1.1.7",
-			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
-			"integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
-			"requires": {
-				"inherits": "^2.0.3",
-				"minimalistic-assert": "^1.0.1"
-			}
-		},
-		"hmac-drbg": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
-			"integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
-			"requires": {
-				"hash.js": "^1.0.3",
-				"minimalistic-assert": "^1.0.0",
-				"minimalistic-crypto-utils": "^1.0.1"
-			}
-		},
 		"inflight": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -339,6 +864,11 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+		},
+		"invert-kv": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
 		},
 		"is-arguments": {
 			"version": "1.0.4",
@@ -357,6 +887,14 @@
 			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
 			"integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
 			"dev": true
+		},
+		"is-fullwidth-code-point": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+			"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+			"requires": {
+				"number-is-nan": "^1.0.0"
+			}
 		},
 		"is-regex": {
 			"version": "1.0.5",
@@ -386,6 +924,29 @@
 			"resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz",
 			"integrity": "sha1-MwVCrT8KZUZlt3jz6y2an6UHrGQ="
 		},
+		"lcid": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+			"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+			"requires": {
+				"invert-kv": "^1.0.0"
+			}
+		},
+		"lodash.camelcase": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+			"integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
+		},
+		"lodash.clone": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-4.5.0.tgz",
+			"integrity": "sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y="
+		},
+		"long": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+			"integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+		},
 		"make-error": {
 			"version": "1.3.6",
 			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
@@ -412,16 +973,6 @@
 				"mime-db": "1.43.0"
 			}
 		},
-		"minimalistic-assert": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-			"integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
-		},
-		"minimalistic-crypto-utils": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-			"integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
-		},
 		"minimatch": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -442,10 +993,10 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 		},
-		"node-addon-api": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.0.tgz",
-			"integrity": "sha512-ASCL5U13as7HhOExbT6OlWJJUV/lLzL2voOSP1UVehpRD8FbSrSDjfScK/KwAvVTI5AS6r4VwbOMlIqtvRidnA=="
+		"nan": {
+			"version": "2.14.0",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+			"integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
 		},
 		"node-docker-api": {
 			"version": "1.1.22",
@@ -461,10 +1012,10 @@
 			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
 			"integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
 		},
-		"node-gyp-build": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.1.tgz",
-			"integrity": "sha512-XyCKXsqZfLqHep1hhsMncoXuUNt/cXCjg1+8CLbu69V1TKuPiOeSGbL9n+k/ByKH8UT0p4rdIX8XkTRZV0i7Sw=="
+		"number-is-nan": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
 		},
 		"object-inspect": {
 			"version": "1.7.0",
@@ -505,6 +1056,19 @@
 				"wrappy": "1"
 			}
 		},
+		"optjs": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/optjs/-/optjs-3.2.2.tgz",
+			"integrity": "sha1-aabOicRCpEQDFBrS+bNwvVu29O4="
+		},
+		"os-locale": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+			"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+			"requires": {
+				"lcid": "^1.0.0"
+			}
+		},
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -516,6 +1080,33 @@
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
 			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
 			"dev": true
+		},
+		"protobufjs": {
+			"version": "6.8.9",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.8.9.tgz",
+			"integrity": "sha512-j2JlRdUeL/f4Z6x4aU4gj9I2LECglC+5qR2TrWb193Tla1qfdaNQTZ8I27Pt7K0Ajmvjjpft7O3KWTGciz4gpw==",
+			"requires": {
+				"@protobufjs/aspromise": "^1.1.2",
+				"@protobufjs/base64": "^1.1.2",
+				"@protobufjs/codegen": "^2.0.4",
+				"@protobufjs/eventemitter": "^1.1.0",
+				"@protobufjs/fetch": "^1.1.0",
+				"@protobufjs/float": "^1.0.2",
+				"@protobufjs/inquire": "^1.1.0",
+				"@protobufjs/path": "^1.1.2",
+				"@protobufjs/pool": "^1.1.0",
+				"@protobufjs/utf8": "^1.1.0",
+				"@types/long": "^4.0.0",
+				"@types/node": "^10.1.0",
+				"long": "^4.0.0"
+			},
+			"dependencies": {
+				"@types/node": {
+					"version": "10.17.18",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.18.tgz",
+					"integrity": "sha512-DQ2hl/Jl3g33KuAUOcMrcAOtsbzb+y/ufakzAdeK9z/H/xsvkpbETZZbPNMIiQuk24f5ZRMCcZIViAwyFIiKmg=="
+				}
+			}
 		},
 		"readable-stream": {
 			"version": "1.0.34",
@@ -556,15 +1147,10 @@
 				"through": "~2.3.4"
 			}
 		},
-		"secp256k1": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.0.tgz",
-			"integrity": "sha512-0w0zse+Iku13O58SVE9/DhyCKWNsKb+n/vMqLOGICgSqxWuXZs+eajBf9uVOgk5QfNvTY/mx0QSqYxkcz802dw==",
-			"requires": {
-				"elliptic": "^6.5.2",
-				"node-addon-api": "^2.0.0",
-				"node-gyp-build": "^4.2.0"
-			}
+		"safe-buffer": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+			"integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
 		},
 		"source-map": {
 			"version": "0.6.1",
@@ -586,6 +1172,16 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/split-ca/-/split-ca-1.0.1.tgz",
 			"integrity": "sha1-bIOv82kvphJW4M0ZfgXp3hV2kaY="
+		},
+		"string-width": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+			"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+			"requires": {
+				"code-point-at": "^1.0.0",
+				"is-fullwidth-code-point": "^1.0.0",
+				"strip-ansi": "^3.0.0"
+			}
 		},
 		"string.prototype.trim": {
 			"version": "1.2.1",
@@ -622,6 +1218,14 @@
 			"version": "0.10.31",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
 			"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+		},
+		"strip-ansi": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+			"requires": {
+				"ansi-regex": "^2.0.0"
+			}
 		},
 		"tape": {
 			"version": "4.13.2",
@@ -670,11 +1274,44 @@
 			"integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
 			"dev": true
 		},
+		"window-size": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
+			"integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY="
+		},
+		"wrap-ansi": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+			"requires": {
+				"string-width": "^1.0.1",
+				"strip-ansi": "^3.0.1"
+			}
+		},
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
 			"dev": true
+		},
+		"y18n": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+			"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+		},
+		"yargs": {
+			"version": "3.32.0",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+			"integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
+			"requires": {
+				"camelcase": "^2.0.1",
+				"cliui": "^3.0.3",
+				"decamelize": "^1.1.1",
+				"os-locale": "^1.4.0",
+				"string-width": "^1.0.1",
+				"window-size": "^0.1.4",
+				"y18n": "^3.2.0"
+			}
 		},
 		"yn": {
 			"version": "3.1.1",

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -31,13 +31,11 @@
     "@mesg/api": "^0.2.0",
     "debug": "^4.1.1",
     "node-docker-api": "^1.1.22",
-    "node-fetch": "^2.6.0",
-    "secp256k1": "^4.0.0"
+    "node-fetch": "^2.6.0"
   },
   "devDependencies": {
     "@types/long": "^4.0.1",
     "@types/node-fetch": "^2.5.5",
-    "@types/secp256k1": "^3.5.3",
     "@types/tape": "^4.2.34",
     "tape": "^4.13.2",
     "ts-node": "^8.4.1",

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -1,8 +1,7 @@
 import API from '@mesg/api/lib/lcd'
 import Account from "@mesg/api/lib/account-lcd"
-import { createHash } from 'crypto'
-import { ecdsaSign } from "secp256k1"
 import { IService } from '@mesg/api/lib/service-lcd'
+import Transaction from '@mesg/api/lib/transaction'
 
 export type RunnerInfo = {
   hash: string
@@ -53,12 +52,7 @@ export default class Runner {
       serviceHash: serviceHash,
       envHash: envHash
     }
-    const hash = createHash('sha256')
-      .update(JSON.stringify(value))
-      .digest('hex')
-    const buf = Buffer.from(hash, 'hex')
-
-    const ecdsa = ecdsaSign(buf, Account.getPrivateKey(this._mnemonic))
+    const ecdsa = Transaction.sign(JSON.stringify(value), Account.getPrivateKey(this._mnemonic))
     const signature = Buffer.from(ecdsa.signature).toString('base64')
     return JSON.stringify({ signature, value })
   }


### PR DESCRIPTION
The functions to derive a mnemonic and to sign a message are now accessible throw 
- `Account.deriveMnemonic(mnemonic: string, path: string = defaultHDPath)`
- `Transaction.sign(message: string, ecpairPriv: Buffer)`

This signature from the runner has been replaced by this function