### PR TITLE
Fix issue with target port

### DIFF
--- a/packages/runner/CHANGELOG.md
+++ b/packages/runner/CHANGELOG.md
@@ -6,6 +6,8 @@
 #### Improvements
 #### Bug fixes
 
+- [#](https://github.com/mesg-foundation/js-sdk/pull/) Handle ports with destination from mesg services
+
 ## [v0.1.3](https://github.com/mesg-foundation/js-sdk/releases/tag/%40mesg%runner%400.1.3)
 
 #### Bug fixes

--- a/packages/runner/CHANGELOG.md
+++ b/packages/runner/CHANGELOG.md
@@ -6,7 +6,7 @@
 #### Improvements
 #### Bug fixes
 
-- [#](https://github.com/mesg-foundation/js-sdk/pull/) Handle ports with destination from mesg services
+- [#234](https://github.com/mesg-foundation/js-sdk/pull/234) Handle ports with destination from mesg services
 
 ## [v0.1.3](https://github.com/mesg-foundation/js-sdk/releases/tag/%40mesg%runner%400.1.3)
 

--- a/packages/runner/src/providers/container/container.ts
+++ b/packages/runner/src/providers/container/container.ts
@@ -79,8 +79,10 @@ export default class Container {
     if (!this._containerInfo.HostConfig) this._containerInfo.HostConfig = {}
     if (!this._containerInfo.HostConfig.PortBindings) this._containerInfo.HostConfig.PortBindings = {}
     for (const port of ports || []) {
-      this._containerInfo.ExposedPorts[`${port}/tcp`] = {}
-      this._containerInfo.HostConfig.PortBindings[`${port}/tcp`] = [{ HostPort: port }]
+      let [target, host] = port.split(':')
+      if (!host) host = target
+      this._containerInfo.ExposedPorts[`${target}/tcp`] = {}
+      this._containerInfo.HostConfig.PortBindings[`${target}/tcp`] = [{ HostPort: host }]
     }
     return this
   }


### PR DESCRIPTION
Services that define a port with a source and target port eg: `80:3000` are now supported again