### PR TITLE
Support multi runners for services

### DIFF
--- a/packages/runner/CHANGELOG.md
+++ b/packages/runner/CHANGELOG.md
@@ -6,7 +6,7 @@
 #### Improvements
 #### Bug fixes
 
-- [#](https://github.com/mesg-foundation/js-sdk/pull/) Fix docker container names to support multi instances fix #232
+- [#235](https://github.com/mesg-foundation/js-sdk/pull/235) Fix docker container names to support multi instances fix #232
 
 ## [v0.1.3](https://github.com/mesg-foundation/js-sdk/releases/tag/%40mesg%runner%400.1.3)
 

--- a/packages/runner/CHANGELOG.md
+++ b/packages/runner/CHANGELOG.md
@@ -6,6 +6,8 @@
 #### Improvements
 #### Bug fixes
 
+- [#](https://github.com/mesg-foundation/js-sdk/pull/) Fix docker container names to support multi instances fix #232
+
 ## [v0.1.3](https://github.com/mesg-foundation/js-sdk/releases/tag/%40mesg%runner%400.1.3)
 
 #### Bug fixes

--- a/packages/runner/src/providers/container/index.ts
+++ b/packages/runner/src/providers/container/index.ts
@@ -46,7 +46,7 @@ export default class DockerContainer implements Provider {
 
     let serviceNetwork = await this.findNetwork(labels)
     if (!serviceNetwork) serviceNetwork = await this._client.network.create({
-      name: PREFIX + service.hash,
+      name: PREFIX + runnerHash,
       labels
     })
 
@@ -64,7 +64,7 @@ export default class DockerContainer implements Provider {
           'mesg.dependency': dep.key,
         },
         HostConfig: {
-          Mounts: this.convertVolumes(service, dep.volumes, dep.volumesFrom, dep),
+          Mounts: this.convertVolumes(service, runnerHash, dep.volumes, dep.volumesFrom, dep),
           RestartPolicy: {
             Name: 'on-failure',
             MaximumRetryCount: MAX_RETRY
@@ -90,7 +90,7 @@ export default class DockerContainer implements Provider {
         'mesg.dependency': 'service'
       },
       HostConfig: {
-        Mounts: this.convertVolumes(service, service.configuration.volumes, service.configuration.volumesFrom),
+        Mounts: this.convertVolumes(service, runnerHash, service.configuration.volumes, service.configuration.volumesFrom),
         RestartPolicy: {
           Name: 'on-failure',
           MaximumRetryCount: MAX_RETRY
@@ -158,11 +158,11 @@ export default class DockerContainer implements Provider {
     return tag
   }
 
-  private convertVolumes(service: IService, volumes: string[], volumesFrom: string[], dependency?: IDependency): any[] {
+  private convertVolumes(service: IService, runnerHash: string, volumes: string[], volumesFrom: string[], dependency?: IDependency): any[] {
     const res = []
     for (const volume of volumes || []) {
       res.push({
-        Source: this.volumeName(service, volume, dependency),
+        Source: this.volumeName(runnerHash, volume, dependency),
         Target: volume,
         Type: 'volume'
       })
@@ -174,7 +174,7 @@ export default class DockerContainer implements Provider {
       if (!dependency) throw new Error(`dependency "${dependency}" missing`)
       for (const volume of dependency.volumes) {
         res.push({
-          Source: this.volumeName(service, volume, dependency),
+          Source: this.volumeName(runnerHash, volume, dependency),
           Target: volume,
           Type: 'volume'
         })
@@ -183,10 +183,10 @@ export default class DockerContainer implements Provider {
     return res
   }
 
-  private volumeName(service: IService, vol: string, dependency?: IDependency): string {
+  private volumeName(runnerHash: string, vol: string, dependency?: IDependency): string {
     return createHash('sha256')
       .update(JSON.stringify([
-        service.hash,
+        runnerHash,
         dependency ? dependency.key : null,
         vol
       ]))

--- a/packages/runner/src/providers/container/index.ts
+++ b/packages/runner/src/providers/container/index.ts
@@ -70,7 +70,7 @@ export default class DockerContainer implements Provider {
             MaximumRetryCount: MAX_RETRY
           }
         }
-      }, PREFIX + service.hash + '_' + dep.key, this._client)
+      }, PREFIX + runnerHash + '_' + dep.key, this._client)
       container.addPorts(dep.ports)
       container.connectTo(serviceNetwork, [dep.key])
       await container.start()
@@ -96,7 +96,7 @@ export default class DockerContainer implements Provider {
           MaximumRetryCount: MAX_RETRY
         }
       }
-    }, PREFIX + service.hash, this._client)
+    }, PREFIX + runnerHash, this._client)
     container.addPorts(service.configuration.ports)
     container.connectTo(serviceNetwork, ['service'])
     container.connectTo(engineNetwork, ['engine'])


### PR DESCRIPTION
fix #232

We can now run multiple instances of the same service without having any conflicts in the container created