### PR TITLE
Improve process dev commands

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 #### Breaking Changes
 #### Improvements
+
+- [#236](https://github.com/mesg-foundation/js-sdk/pull/236) Improve the `process:dev` and `dev` command with more details of the deployment
+
 #### Bug fixes
 
 ## [v0.4.0](https://github.com/mesg-foundation/js-sdk/releases/tag/%40mesg%2Fcli%400.4.0)

--- a/packages/cli/src/commands/deploy/service.ts
+++ b/packages/cli/src/commands/deploy/service.ts
@@ -5,7 +5,6 @@ import { IDefinition } from '@mesg/api/lib/service'
 import { compile } from '../../utils/service'
 import { loginFromCredential } from '../../utils/login'
 import firebase from '../../utils/firebase'
-import styledJSON from 'cli-ux/lib/styled/json'
 
 const ipfsClient = require('ipfs-http-client')
 
@@ -33,7 +32,7 @@ export default class Service extends Command {
 
 
     let definition: IDefinition
-    let res: any
+    let serviceHash: string
 
     const { user } = await loginFromCredential(this.config.configDir, password)
     const tasks = new Listr([
@@ -45,18 +44,65 @@ export default class Service extends Command {
       },
       {
         title: 'Creating service',
-        task: async (ctx, task) => {
-          res = await firebase.firestore().collection('services').add({
+        task: async () => {
+          const res = await firebase.firestore().collection('services').add({
             uid: user.uid,
             definition
           })
+          serviceHash = await new Promise((resolve, reject) => {
+            firebase.firestore()
+              .collection('services').doc(res.id)
+              .onSnapshot((snapshot) => {
+                const data = snapshot.data()
+                if (!data.hash) return
+                resolve(data.hash)
+              }, reject)
+          })
         }
-      },
+      }
     ])
     await tasks.run()
 
-    styledJSON(res)
-    // this.log(`Service deployed with the hash ${service.hash}`)
-    // this.log(`https://explorer.testnet.mesg.com/services/${service.hash}`)
+    this.log('')
+    this.log(`Service deployed with the hash ${serviceHash}`)
+    this.log('')
+
+    const { deploy } = await prompt({ type: 'confirm', name: 'deploy', message: 'Would you like to start this service?' })
+
+    if (!deploy) return
+
+    const env = await this.getEnv(definition.configuration.env || [])
+
+    const res = await firebase.firestore().collection('runners').add({
+      uid: user.uid,
+      serviceHash: serviceHash,
+      env: env
+    })
+
+    const runnerHash = await new Promise((resolve, reject) => {
+      firebase.firestore()
+        .collection('runners').doc(res.id)
+        .onSnapshot((snapshot) => {
+          const data = snapshot.data()
+          if (!data.hash) return
+          resolve(data.hash)
+        }, reject)
+    })
+
+    this.log('')
+    this.log(`Service started with the runner hash ${runnerHash}`)
+
+    await firebase.firestore().terminate()
+  }
+
+  async getEnv(envs: string[]): Promise<string[]> {
+    if (!envs.length) return []
+
+    const res = await prompt(envs.map((x: string) => ({
+      name: x.split('=')[0],
+      default: x.split('=')[1],
+      type: 'input'
+    }))) as { [key: string]: string }
+    return Object.keys(res).map(x => `${x}=${res[x]}`)
   }
 }

--- a/packages/cli/src/commands/deploy/service.ts
+++ b/packages/cli/src/commands/deploy/service.ts
@@ -105,8 +105,9 @@ export default class Service extends Command {
 
     unsubscribeLogs = res.collection('logs').onSnapshot(
       snapshots => {
-        for (const doc of snapshots.docs) {
-          const data = doc.data()
+        for (const change of snapshots.docChanges()) {
+          if (change.type !== 'added') continue
+          const data = change.doc.data()
           if (data.level === 'error') return eventEmitter.emit('error', new Error(data.message))
           eventEmitter.emit('data', data)
         }

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -14,11 +14,10 @@ import * as Runner from '../utils/runner'
 import * as Process from '../utils/process'
 import * as base58 from '@mesg/api/lib/util/base58'
 import version from '../version'
-import { IService } from '@mesg/api/lib/service'
-import { IProcess } from '@mesg/api/lib/process'
+import { IDefinition as IServiceDefinition } from '@mesg/api/lib/service'
+import { IDefinition as IProcessDefinition } from '@mesg/api/lib/process'
 import chalk from 'chalk'
 import { decode } from '@mesg/orchestrator/lib/encoder'
-import { RunnerInfo } from '@mesg/runner'
 import sign from '../utils/sign'
 
 const ipfsClient = require('ipfs-http-client')
@@ -43,9 +42,9 @@ export default class Dev extends Command {
   private ipfsClient = ipfsClient('ipfs.app.mesg.com', '5001', { protocol: 'http' })
   private orchestrator = new Orchestrator(this.orchestratorEndpoint)
   private logs: grpc.ClientReadableStream<Execution.mesg.types.IExecution>
-  private services: IService[] = []
-  private processes: IProcess[] = []
-  private runners: RunnerInfo[] = []
+  private processesToDeploy: { [key: string]: IProcessDefinition } = {}
+  private servicesToDeploy: { [key: string]: IServiceDefinition } = {}
+  private runnersToDeploy: { [key: string]: { serviceHash: string, env: string[] } } = {}
 
   async run() {
     const { args, flags } = this.parse(Dev)
@@ -58,56 +57,75 @@ export default class Dev extends Command {
     const env = Object.keys(envs).reduce((prev, x) => [...prev, `${x}=${envs[x]}`], [])
 
     const tasks = new Listr([
-      Environment.start
-    ])
-
-    const serviceDirs = readdirSync(join(args.PATH, 'services'), { withFileTypes: true })
-      .filter(x => x.isDirectory() || x.isSymbolicLink())
-    for (const dir of serviceDirs) {
-      tasks.add([
-        {
-          title: `Creating service "${dir.name}"`,
-          task: async (ctx) => {
-            const definition = await Service.compile(join(args.PATH, 'services', dir.name), this.ipfsClient)
-            const service = await Service.create(this.lcd, definition, ctx.config.mnemonic)
-            this.services.push(service)
+      Environment.start,
+      {
+        title: 'Compiling processes',
+        task: async () => {
+          const processFiles = readdirSync(args.PATH, { withFileTypes: true })
+            .filter(x => x.isFile() && x.name.match(/\.(yml|yaml)/))
+          return new Listr(processFiles.map(file => ({
+            title: file.name,
+            task: async ctx => {
+              const compilation = await Process.compile(
+                join(args.PATH, file.name),
+                env,
+                async ({ src, env }) => {
+                  const definition = await Service.compile(src, this.ipfsClient)
+                  const serviceHash = await this.lcd.service.hash(definition)
+                  const runner = await this.lcd.runner.hash(ctx.engineAddress, serviceHash, env)
+                  this.servicesToDeploy[serviceHash] = definition
+                  this.runnersToDeploy[runner.runnerHash] = { serviceHash, env }
+                  return {
+                    hash: runner.runnerHash,
+                    instanceHash: runner.instanceHash
+                  }
+                }
+              )
+              const hash = await this.lcd.process.hash(compilation.definition)
+              this.processesToDeploy[hash] = compilation.definition
+            }
+          })))
+        }
+      },
+      {
+        title: 'Creating services',
+        task: () => new Listr(Object.keys(this.servicesToDeploy).map(hash => ({
+          title: this.servicesToDeploy[hash].name,
+          skip: () => this.lcd.service.exists(hash),
+          task: async ctx => await Service.create(this.lcd, this.servicesToDeploy[hash], ctx.config.mnemonic)
+        })))
+      },
+      {
+        title: 'Starting services',
+        task: () => new Listr(Object.keys(this.runnersToDeploy).map(hash => ({
+          title: hash,
+          skip: () => this.lcd.runner.exists(hash),
+          task: async ctx => await Runner.create(this.lcd, this.lcdEndpoint, this.orchestratorEndpoint, ctx.config.mnemonic, ctx.engineAddress, this.runnersToDeploy[hash].serviceHash, this.runnersToDeploy[hash].env)
+        })))
+      },
+      {
+        title: 'Creating processes',
+        task: () => new Listr(Object.keys(this.processesToDeploy).map(hash => ({
+          title: this.processesToDeploy[hash].name,
+          skip: () => this.lcd.process.exists(hash),
+          task: async ctx => await Process.create(this.lcd, this.processesToDeploy[hash], ctx.config.mnemonic)
+        })))
+      },
+      {
+        title: 'Fetching logs',
+        task: ctx => {
+          const payload = {
+            filter: {
+              statuses: [
+                Status.Completed,
+                Status.Failed
+              ]
+            }
           }
+          this.logs = this.orchestrator.execution.stream(payload, sign(payload, ctx.config.mnemonic))
         }
-      ])
-    }
-
-    const processFiles = readdirSync(args.PATH, { withFileTypes: true })
-      .filter(x => x.isFile() && x.name.match(/\.(yml|yaml)/))
-
-    for (const file of processFiles) {
-      tasks.add({
-        title: `Creating process "${file.name}"`,
-        task: async (ctx) => {
-          const compilation = await Process.compile(join(args.PATH, file.name), this.ipfsClient, this.lcd, this.lcdEndpoint, this.orchestratorEndpoint, ctx.config.mnemonic, ctx.engineAddress, env)
-          const deployedProcess = await Process.create(this.lcd, compilation.definition, ctx.config.mnemonic)
-          this.processes.push(deployedProcess)
-          this.runners = [
-            ...this.runners,
-            ...compilation.runners,
-          ].filter((item, i, self) => i === self.indexOf(item))
-        }
-      })
-    }
-
-    tasks.add({
-      title: 'Fetching logs',
-      task: ctx => {
-        const payload = {
-          filter: {
-            statuses: [
-              Status.Completed,
-              Status.Failed
-            ]
-          }
-        }
-        this.logs = this.orchestrator.execution.stream(payload, sign(payload, ctx.config.mnemonic))
       }
-    })
+    ])
 
     const { config, engineAddress } = await tasks.run({
       configDir: this.config.dataDir,
@@ -120,7 +138,7 @@ export default class Dev extends Command {
       .on('error', (error: Error) => { this.warn('Result stream error: ' + error.message) })
       .on('data', (execution) => {
         if (!execution.processHash) return
-        const process = this.processes.find(x => x.hash === base58.encode(execution.processHash))
+        const process = this.processesToDeploy[base58.encode(execution.processHash)]
         if (!process) return
 
         const prefix = `[${process.name}][${execution.nodeKey}] - ${base58.encode(execution.instanceHash)} - ${execution.taskKey}`
@@ -144,20 +162,17 @@ export default class Dev extends Command {
         },
         {
           title: 'Stopping running services',
-          task: async () => {
-            const uniqueRunners = this.runners.filter((item, i, self) => i === self.indexOf(item))
-            for (const runner of uniqueRunners) {
-              await Runner.stop(this.lcdEndpoint, this.orchestratorEndpoint, config.mnemonic, engineAddress, runner.hash)
-            }
-          }
+          task: async () => new Listr(Object.keys(this.runnersToDeploy).map(hash => ({
+            title: hash,
+            task: async () => Runner.stop(this.lcdEndpoint, this.orchestratorEndpoint, config.mnemonic, engineAddress, hash)
+          })))
         },
         {
           title: 'Deleting processes',
-          task: async () => {
-            for (const process of this.processes) {
-              await Process.remove(this.lcd, process, config.mnemonic)
-            }
-          }
+          task: async () => new Listr(Object.keys(this.processesToDeploy).map(hash => ({
+            title: this.processesToDeploy[hash].name,
+            task: async () => await Process.remove(this.lcd, hash, config.mnemonic)
+          })))
         },
         Environment.stop
       ]).run({

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -65,11 +65,12 @@ export default class Dev extends Command {
             .filter(x => x.isFile() && x.name.match(/\.(yml|yaml)/))
           return new Listr(processFiles.map(file => ({
             title: file.name,
-            task: async ctx => {
+            task: async (ctx, task) => {
               const compilation = await Process.compile(
                 join(args.PATH, file.name),
                 env,
                 async ({ src, env }) => {
+                  task.output = `compiling ${src}`
                   const definition = await Service.compile(src, this.ipfsClient)
                   const serviceHash = await this.lcd.service.hash(definition)
                   const runner = await this.lcd.runner.hash(ctx.engineAddress, serviceHash, env)

--- a/packages/cli/src/commands/process/dev.ts
+++ b/packages/cli/src/commands/process/dev.ts
@@ -60,12 +60,11 @@ export default class Dev extends Command {
       {
         title: 'Compiling process',
         task: async (ctx, task) => {
-          const title = task.title
           compilation = await Process.compile(
             args.PROCESS_FILE,
             flags.env,
             async ({ env, src }) => {
-              task.title = `${title} (compiling ${src})`
+              task.output = `compiling ${src}`
               const definition = await Service.compile(src, this.ipfsClient)
               const serviceHash = await this.lcd.service.hash(definition)
               const runner = await this.lcd.runner.hash(ctx.engineAddress, serviceHash, env)

--- a/packages/cli/src/commands/process/dev.ts
+++ b/packages/cli/src/commands/process/dev.ts
@@ -61,22 +61,22 @@ export default class Dev extends Command {
         title: 'Compiling process',
         task: async (ctx, task) => {
           const title = task.title
-          const instanceResolver = async (instanceObject: any): Promise<RunnerInfo> => {
-            if (!instanceObject.instanceHash && !instanceObject.instance) throw new Error('"instanceHash" or "instance" not found in the process\'s definition')
-            if (instanceObject.instanceHash) return instanceObject.instanceHash
-            const { src, env } = instanceObject.instance
-            task.title = `${title} (compiling ${src})`
-            const definition = await Service.compile(src, this.ipfsClient)
-            const serviceHash = await this.lcd.service.hash(definition)
-            const runner = await this.lcd.runner.hash(ctx.engineAddress, serviceHash, env)
-            servicesToDeploy[serviceHash] = definition
-            runnersToDeploy[runner.runnerHash] = { serviceHash, env }
-            return {
-              hash: runner.runnerHash,
-              instanceHash: runner.instanceHash
+          compilation = await Process.compile(
+            args.PROCESS_FILE,
+            flags.env,
+            async ({ env, src }) => {
+              task.title = `${title} (compiling ${src})`
+              const definition = await Service.compile(src, this.ipfsClient)
+              const serviceHash = await this.lcd.service.hash(definition)
+              const runner = await this.lcd.runner.hash(ctx.engineAddress, serviceHash, env)
+              servicesToDeploy[serviceHash] = definition
+              runnersToDeploy[runner.runnerHash] = { serviceHash, env }
+              return {
+                hash: runner.runnerHash,
+                instanceHash: runner.instanceHash
+              }
             }
-          }
-          compilation = await Process.compile(args.PROCESS_FILE, instanceResolver, flags.env)
+          )
         }
       },
       {

--- a/packages/cli/src/commands/process/dev.ts
+++ b/packages/cli/src/commands/process/dev.ts
@@ -80,7 +80,7 @@ export default class Dev extends Command {
         }
       },
       {
-        title: 'Create services',
+        title: 'Creating services',
         task: () => new Listr(Object.keys(servicesToDeploy).map(hash => ({
           title: servicesToDeploy[hash].name,
           skip: () => this.lcd.service.exists(hash),
@@ -88,7 +88,7 @@ export default class Dev extends Command {
         })))
       },
       {
-        title: 'Start services',
+        title: 'Starting services',
         task: () => new Listr(Object.keys(runnersToDeploy).map(hash => ({
           title: hash,
           skip: () => this.lcd.runner.exists(hash),
@@ -151,7 +151,7 @@ export default class Dev extends Command {
         {
           title: 'Deleting process',
           task: async () => {
-            if (deployedProcess) await Process.remove(this.lcd, deployedProcess, config.mnemonic)
+            if (deployedProcess) await Process.remove(this.lcd, deployedProcess.hash, config.mnemonic)
           }
         },
         {

--- a/packages/cli/src/commands/service/dev.ts
+++ b/packages/cli/src/commands/service/dev.ts
@@ -73,7 +73,7 @@ export default class Dev extends Command {
       {
         title: 'Starting service',
         task: async ctx => {
-          runner = await Runner.create(this.lcdEndpoint, this.orchestratorEndpoint, ctx.config.mnemonic, ctx.engineAddress, service.hash, flags.env)
+          runner = await Runner.create(this.lcd, this.lcdEndpoint, this.orchestratorEndpoint, ctx.config.mnemonic, ctx.engineAddress, service.hash, flags.env)
         }
       },
       {

--- a/packages/cli/src/utils/firebase.ts
+++ b/packages/cli/src/utils/firebase.ts
@@ -1,0 +1,12 @@
+import Firebase from 'firebase'
+
+export default Firebase.initializeApp({
+  apiKey: "AIzaSyDp-sk6i2gICPGv66O13l_ttoitXu9849w",
+  authDomain: "platform-f4e92.firebaseapp.com",
+  databaseURL: "https://platform-f4e92.firebaseio.com",
+  projectId: "platform-f4e92",
+  storageBucket: "platform-f4e92.appspot.com",
+  messagingSenderId: "581848581612",
+  appId: "1:581848581612:web:44440228033335dbc52cc9",
+  measurementId: "G-VQKX4K7PTT"
+})

--- a/packages/cli/src/utils/firebase.ts
+++ b/packages/cli/src/utils/firebase.ts
@@ -1,4 +1,5 @@
 import Firebase from 'firebase'
+import { EventEmitter } from 'events'
 
 export default Firebase.initializeApp({
   apiKey: "AIzaSyDp-sk6i2gICPGv66O13l_ttoitXu9849w",
@@ -10,3 +11,49 @@ export default Firebase.initializeApp({
   appId: "1:581848581612:web:44440228033335dbc52cc9",
   measurementId: "G-VQKX4K7PTT"
 })
+
+export type DeployerEvents = EventEmitter & {
+  promise: () => Promise<any>
+}
+
+export const deploy = async (type: 'service' | 'process' | 'runner', definition: any, uid: string): Promise<DeployerEvents> => {
+  const res = await Firebase.firestore().collection('deployments').add({ type, uid, definition })
+  const eventEmitter = new EventEmitter() as DeployerEvents
+
+  let unsubscribeLogs: () => void
+  let unsubscribeDeployment: () => void
+
+  const clearListeners = () => {
+    if (unsubscribeDeployment) unsubscribeDeployment()
+    if (unsubscribeLogs) unsubscribeLogs()
+  }
+
+  unsubscribeLogs = res.collection('logs').onSnapshot(
+    snapshots => {
+      for (const change of snapshots.docChanges()) {
+        if (change.type !== 'added') continue
+        const data = change.doc.data()
+        if (data.level === 'error') return eventEmitter.emit('error', new Error(data.message))
+        eventEmitter.emit('data', data)
+      }
+    },
+    error => eventEmitter.emit('error', error)
+  )
+
+  unsubscribeDeployment = res.onSnapshot(
+    async snapshot => {
+      const data = snapshot.data()
+      if (!data.resourceRef) return
+      const resource = await data.resourceRef.get()
+      eventEmitter.emit('end', resource.data().definition)
+    },
+    error => eventEmitter.emit('error', error)
+  )
+  eventEmitter.on('error', clearListeners)
+  eventEmitter.on('end', clearListeners)
+  eventEmitter.promise = () => new Promise((resolve, reject) => {
+    eventEmitter.on('end', resolve)
+    eventEmitter.on('error', reject)
+  })
+  return eventEmitter
+}

--- a/packages/cli/src/utils/login.ts
+++ b/packages/cli/src/utils/login.ts
@@ -2,19 +2,9 @@ import Vault from '@mesg/vault'
 import FileStore from '@mesg/vault/lib/store/file'
 import Firebase from 'firebase'
 import { join } from 'path'
+import firebase from './firebase'
 
-const app = Firebase.initializeApp({
-  apiKey: "AIzaSyDp-sk6i2gICPGv66O13l_ttoitXu9849w",
-  authDomain: "platform-f4e92.firebaseapp.com",
-  databaseURL: "https://platform-f4e92.firebaseio.com",
-  projectId: "platform-f4e92",
-  storageBucket: "platform-f4e92.appspot.com",
-  messagingSenderId: "581848581612",
-  appId: "1:581848581612:web:44440228033335dbc52cc9",
-  measurementId: "G-VQKX4K7PTT"
-})
-
-const vaultKey = app.name
+const vaultKey = firebase.name
 const getVault = (configDir: string) => new Vault<Firebase.auth.AuthCredential>(new FileStore(join(configDir, 'credentials.json')))
 
 export const loginFromCredential = async (configDir: string, password: string): Promise<Firebase.auth.UserCredential> => {
@@ -22,7 +12,7 @@ export const loginFromCredential = async (configDir: string, password: string): 
   const vault = getVault(configDir)
   const credential = vault.get(vaultKey, password) as any
   try {
-    return app.auth().signInWithEmailAndPassword(credential.email, credential.password)
+    return firebase.auth().signInWithEmailAndPassword(credential.email, credential.password)
   } catch (e) {
     throw new Error(e.message)
   }
@@ -35,7 +25,7 @@ export const loggedIn = (configDir: string): boolean => {
 
 export const login = async (configDir: string, email: string, password: string): Promise<Firebase.auth.UserCredential> => {
   if (loggedIn(configDir)) throw new Error('Already logged in')
-  const res = await app.auth().signInWithEmailAndPassword(email, password)
+  const res = await firebase.auth().signInWithEmailAndPassword(email, password)
   const vault = getVault(configDir)
   vault.set(vaultKey, Firebase.auth.EmailAuthProvider.credential(email, password), password)
   return res

--- a/packages/cli/src/utils/process.ts
+++ b/packages/cli/src/utils/process.ts
@@ -11,12 +11,14 @@ export type CompilationResult = {
   runners: RunnerInfo[]
 }
 
-export const compile = async (processFilePath: string, instanceResolver: (definition: any) => Promise<RunnerInfo>, env: string[] = []): Promise<CompilationResult> => {
+export const compile = async (processFilePath: string, env: string[], instanceResolver: (definition: { src: string, env: string[] }) => Promise<RunnerInfo>): Promise<CompilationResult> => {
   const runners: RunnerInfo[] = []
 
   const definition = await compileProcess(
     readFileSync(processFilePath),
     async definition => {
+      if (!definition.instanceHash && !definition.instance) throw new Error('"instanceHash" or "instance" not found in the process\'s definition')
+      if (definition.instanceHash) return definition.instanceHash
       const runner = await instanceResolver(definition)
       if (!runners.find(x => x.hash === runner.hash)) runners.push(runner)
       return runner.instanceHash

--- a/packages/cli/src/utils/process.ts
+++ b/packages/cli/src/utils/process.ts
@@ -23,7 +23,7 @@ export const compile = async (processFilePath: string, env: string[], instanceRe
       if (!runners.find(x => x.hash === runner.hash)) runners.push(runner)
       return runner.instanceHash
     },
-    env.reduce((prev, env) => ({
+    (env || []).reduce((prev, env) => ({
       ...prev,
       [env.split('=')[0]]: env.split('=')[1],
     }), {}))

--- a/packages/cli/src/utils/process.ts
+++ b/packages/cli/src/utils/process.ts
@@ -19,7 +19,7 @@ export const compile = async (processFilePath: string, env: string[], instanceRe
     async definition => {
       if (!definition.instanceHash && !definition.instance) throw new Error('"instanceHash" or "instance" not found in the process\'s definition')
       if (definition.instanceHash) return definition.instanceHash
-      const runner = await instanceResolver(definition)
+      const runner = await instanceResolver(definition.instance)
       if (!runners.find(x => x.hash === runner.hash)) runners.push(runner)
       return runner.instanceHash
     },
@@ -51,10 +51,10 @@ export const create = async (lcd: LCD, process: IDefinition, mnemonic: string): 
   }
 }
 
-export const remove = async (lcd: LCD, process: IProcess, mnemonic: string): Promise<void> => {
+export const remove = async (lcd: LCD, processHash: string, mnemonic: string): Promise<void> => {
   const account = await lcd.account.import(mnemonic)
   const tx = await lcd.createTransaction(
-    [lcd.process.deleteMsg(account.address, process.hash)],
+    [lcd.process.deleteMsg(account.address, processHash)],
     account
   )
   await lcd.broadcast(tx.signWithMnemonic(mnemonic))

--- a/packages/cli/src/utils/runner.ts
+++ b/packages/cli/src/utils/runner.ts
@@ -1,14 +1,30 @@
 import Runner, { RunnerInfo } from "@mesg/runner";
 import DockerContainer from "@mesg/runner/lib/providers/container";
+import API from "@mesg/api";
+import { IInstance } from "@mesg/api/lib/instance";
 
-export const create = async (lcdEndpoint: string, orchestratorEndpoint: string, mnemonic: string, engineAddress: string, serviceHash: string, env: string[]): Promise<RunnerInfo> => {
+export const create = async (lcd: API, lcdEndpoint: string, orchestratorEndpoint: string, mnemonic: string, engineAddress: string, serviceHash: string, env: string[]): Promise<RunnerInfo> => {
   const provider = new DockerContainer()
   const runner = new Runner(provider, lcdEndpoint, orchestratorEndpoint, mnemonic, engineAddress)
-  return runner.start(serviceHash, env)
+  const info = await runner.start(serviceHash, env)
+  await waitForInstance(lcd, info.instanceHash)
+  return info
 }
 
 export const stop = async (lcdEndpoint: string, orchestratorEndpoint: string, mnemonic: string, engineAddress: string, runnerHash: string): Promise<void> => {
   const provider = new DockerContainer()
   const runner = new Runner(provider, lcdEndpoint, orchestratorEndpoint, mnemonic, engineAddress)
   return runner.stop(runnerHash)
+}
+
+const waitForInstance = async (lcd: API, hash: string, maxRetries: number = 10, delay: number = 1, count: number = 0): Promise<IInstance> => {
+  while (count < maxRetries) {
+    try {
+      const instance = await lcd.instance.get(hash)
+      return instance
+    } catch (e) {
+      await new Promise((resolve) => setTimeout(resolve, delay))
+    }
+  }
+  throw new Error('instance not started')
 }


### PR DESCRIPTION
dependency: https://github.com/mesg-foundation/js-sdk/pull/231

---

For information the goal of this PR is to be able to compile a process without the need to deploy/start the services. This way we can work on the `deploy:process` command (and optionally ask the user to create/start the missing services.

---

The current `process:dev` and `dev` command were deploying a process and let the user in the dark.
This version improves a lot the flow for the user with the following steps
- Compile the process (based on the future hashes of the instances)
- Create all services needed (list each services that are created)
- Start all services needed (list each runners that are created)
- Create all the process(es) (with the name)
- Delete all that with the same reverse flow when the user exits

https://jumpshare.com/v/gNSHOQOWg8BL2R4VkDrE