### PR TITLE
Remove installation section

### DIFF
--- a/packages/cli/assets/doc.md
+++ b/packages/cli/assets/doc.md
@@ -4,9 +4,6 @@
 
 ## Contents
 
-- [Installation](#Installation)
-  - [MESG SDK](#MESG-SDK)
-  - [Deploy the Service](#Service)
 - [Definitions](#Definitions)
 {{#if configuration}}
   {{#with configuration}}
@@ -27,22 +24,6 @@
   - [{{or name key}}](#{{key}})
   {{/each}}
 {{/if}}
-
-## Installation
-
-### MESG SDK
-
-This service requires [MESG SDK](https://github.com/mesg-foundation/engine) to be installed first.
-
-You can install MESG SDK by running the following command or [follow the installation guide](https://docs.mesg.com/guide/start-here/installation.html).
-
-```bash
-npm install -g @mesg/cli
-```
-
-### Deploy the Service
-
-To deploy this service, go to [this service page](https://marketplace.mesg.com/services/{{sid}}) on the [MESG Marketplace](https://marketplace.mesg.com) and click the button "get/buy this service".
 
 ## Definitions
 


### PR DESCRIPTION
Remove the installation section on the generated documentation. This removes the obsolete link to the marketplace and the future obsolete link for the cli