### PR TITLE
Remove dependency to the service definition

### DIFF
--- a/packages/service/CHANGELOG.md
+++ b/packages/service/CHANGELOG.md
@@ -6,7 +6,7 @@
 #### Improvements
 #### Bug fixes
 
-- [#](https://github.com/mesg-foundation/js-sdk/pull/) Remove unnecessary dependency to the mesg.yml inside the service
+- [#241](https://github.com/mesg-foundation/js-sdk/pull/241) Remove unnecessary dependency to the mesg.yml inside the service
 
 ## [v0.2.0](https://github.com/mesg-foundation/js-sdk/releases/tag/%40mesg%service%400.2.0)
 

--- a/packages/service/CHANGELOG.md
+++ b/packages/service/CHANGELOG.md
@@ -6,6 +6,8 @@
 #### Improvements
 #### Bug fixes
 
+- [#](https://github.com/mesg-foundation/js-sdk/pull/) Remove unnecessary dependency to the mesg.yml inside the service
+
 ## [v0.2.0](https://github.com/mesg-foundation/js-sdk/releases/tag/%40mesg%service%400.2.0)
 
 #### Improvements

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -31,13 +31,10 @@
   "homepage": "https://github.com/mesg-foundation/js-sdk#readme",
   "dependencies": {
     "@grpc/proto-loader": "^0.5.4",
-    "@mesg/api": "^0.3.1",
     "@mesg/orchestrator": "^0.1.3",
-    "grpc": "^1.24.2",
-    "js-yaml": "^3.13.1"
+    "grpc": "^1.24.2"
   },
   "devDependencies": {
-    "@types/js-yaml": "^3.12.1",
     "@types/long": "^4.0.0",
     "@types/node": "^12.12.6",
     "@types/sinon": "^7.5.0",


### PR DESCRIPTION
MESG services don't necessarily need to have a mesg.yml, this is a way to compile these services but the service should be agnostic of any type of compilation.

This PR removes the dependency to the `mesg.yml` definition and the unnecessary `@mesg/api` package